### PR TITLE
Cleaned-up BP version vs resip 1.6

### DIFF
--- a/resip/stack/BranchParameter.cxx
+++ b/resip/stack/BranchParameter.cxx
@@ -116,7 +116,7 @@ BranchParameter::BranchParameter(ParameterTypes::Type type,
 BranchParameter::BranchParameter(ParameterTypes::Type type)
    : Parameter(type),
      mHasMagicCookie(true),
-     mIsMyBranch(true),
+     mIsMyBranch(false), // alexei - KDDI length restriction of 32 chars per branch -  mIsMyBranch(true),
      mTransactionId(Random::getRandomHex(8)),
      mTransportSeq(1),
      mInteropMagicCookie(0),
@@ -203,7 +203,7 @@ BranchParameter::getTransactionId() const
 void
 BranchParameter::incrementTransportSequence()
 {
-   assert(mIsMyBranch);
+//   assert(mIsMyBranch); // alexei
    mTransportSeq++;
 }
 
@@ -249,7 +249,7 @@ void
 BranchParameter::reset(const Data& transactionId)
 {
    mHasMagicCookie = true;
-   mIsMyBranch = true;
+   mIsMyBranch = false;                // alexei
    delete mInteropMagicCookie;
    mInteropMagicCookie = 0;   
 

--- a/resip/stack/CancelClientNonInviteTransaction.hxx
+++ b/resip/stack/CancelClientNonInviteTransaction.hxx
@@ -1,0 +1,45 @@
+#ifndef CancelClientNonInviteTransaction_Include_Guard
+#define CancelClientNonInviteTransaction_Include_Guard
+
+#include "resip/stack/TransactionMessage.hxx"
+
+#include "rutil/Data.hxx"
+
+namespace resip
+{
+class CancelClientNonInviteTransaction : public TransactionMessage
+{
+   public:
+      explicit CancelClientNonInviteTransaction(const resip::Data& tid) :
+         mTid(tid)
+      {}
+      virtual ~CancelClientNonInviteTransaction(){}
+
+/////////////////// Must implement unless abstract ///
+
+      virtual const Data& getTransactionId() const {return mTid;}
+      virtual bool isClientTransaction() const {return true;}
+      virtual EncodeStream& encode(EncodeStream& strm) const
+      {
+         return strm << "CancelClientNonInviteTransaction: " << mTid;
+      }
+      virtual EncodeStream& encodeBrief(EncodeStream& strm) const
+      {
+         return strm << "CancelClientNonInviteTransaction: " << mTid;
+      }
+
+/////////////////// May override ///
+
+      virtual Message* clone() const
+      {
+         return new CancelClientNonInviteTransaction(*this);
+      }
+
+   protected:
+      const resip::Data mTid;
+
+}; // class CancelClientNonInviteTransaction
+
+} // namespace resip
+
+#endif // include guard

--- a/resip/stack/ConnectionBase.cxx
+++ b/resip/stack/ConnectionBase.cxx
@@ -102,6 +102,12 @@ ConnectionBase::preparseNewBytes(int bytesRead, Fifo<TransactionMessage>& fifo)
    DebugLog(<< "In State: " << connectionStates[mConnState]);
    //getConnectionManager().touch(this); -- !dcm!
    
+	
+	//alexkr:
+	const char*  buf_snapshot     = mBuffer + mBufferPos;
+	int          buf_snapshot_len = bytesRead;
+	//:alexkr
+	
   start:   // If there is an overhang come back here, effectively recursing
    
    switch(mConnState)
@@ -345,8 +351,9 @@ ConnectionBase::preparseNewBytes(int bytesRead, Fifo<TransactionMessage>& fifo)
                else
                {
                   Transport::stampReceived(mMessage);
-                  DebugLog(<< "##Connection: " << *this << " received: " << *mMessage);
+                  DebugLog(<< "##Connection: " << *this << " received:\n" << *mMessage);
                   fifo.add(mMessage);
+				   				   		   
                   mMessage = 0;
                }
 
@@ -393,7 +400,7 @@ ConnectionBase::preparseNewBytes(int bytesRead, Fifo<TransactionMessage>& fifo)
             }
             else
             {
-               DebugLog(<< "##ConnectionBase: " << *this << " received: " << *mMessage);
+               DebugLog(<< "##ConnectionBase: " << *this << " received:\n" << *mMessage);
 
                Transport::stampReceived(mMessage);
                fifo.add(mMessage);

--- a/resip/stack/ContentsFactoryBase.cxx
+++ b/resip/stack/ContentsFactoryBase.cxx
@@ -17,13 +17,20 @@ ContentsFactoryBase::ContentsFactoryBase(const Mime& contentType)
 
 ContentsFactoryBase::~ContentsFactoryBase()
 {
-   HashMap<Mime, ContentsFactoryBase*>::iterator i;
-   i = ContentsFactoryBase::getFactoryMap().find(mContentType);
-   ContentsFactoryBase::getFactoryMap().erase(i);
-   if (ContentsFactoryBase::getFactoryMap().size() == 0)
-   {
-      delete &ContentsFactoryBase::getFactoryMap();
-   }
+	//alexkr: we can override Content class factories
+	HashMap<Mime, ContentsFactoryBase*>::iterator i = ContentsFactoryBase::getFactoryMap().find(mContentType);
+	if (i != ContentsFactoryBase::getFactoryMap().end()) {
+        ContentsFactoryBase::getFactoryMap().erase(i);		
+	}
+	if (ContentsFactoryBase::getFactoryMap().size() == 0) {
+		deleteFactoryMap();		
+	}
+}
+
+void ContentsFactoryBase::deleteFactoryMap  ()
+{
+    if  (ContentsFactoryBase::FactoryMap)
+        delete ContentsFactoryBase::FactoryMap, ContentsFactoryBase::FactoryMap = 0;
 }
 
 HashMap<Mime, ContentsFactoryBase*>& 

--- a/resip/stack/ContentsFactoryBase.hxx
+++ b/resip/stack/ContentsFactoryBase.hxx
@@ -22,6 +22,9 @@ class ContentsFactoryBase
 
       static HashMap<Mime, ContentsFactoryBase*>& getFactoryMap();
    private:
+	//alexkr:
+	static void deleteFactoryMap();
+	
       Mime mContentType;
       static HashMap<Mime, ContentsFactoryBase*>* FactoryMap;
 };

--- a/resip/stack/DataParameter.cxx
+++ b/resip/stack/DataParameter.cxx
@@ -26,7 +26,7 @@ DataParameter::DataParameter(ParameterTypes::Type type,
    pb.skipChar(Symbols::EQUALS[0]);
    pb.skipWhitespace();
 
-   if(ParseBuffer::oneOf(*pb.position(),terminators)) // handle cases such as ;tag=
+   if(pb.eof() || ParseBuffer::oneOf(*pb.position(),terminators)) // handle cases such as ;tag=
    {
       throw ParseException("Empty value in string-type parameter.",
                               "DataParameter",

--- a/resip/stack/DataParameter.hxx
+++ b/resip/stack/DataParameter.hxx
@@ -30,7 +30,10 @@ class DataParameter : public Parameter
       
       virtual Parameter* clone() const;
       virtual EncodeStream& encode(EncodeStream& stream) const;
-      
+      	
+	//alexkr: 2check: being used
+	virtual bool bad() const {return mValue.empty();}
+	
    protected:
       DataParameter(const DataParameter& other) 
          : Parameter(other), 

--- a/resip/stack/DnsResult.cxx
+++ b/resip/stack/DnsResult.cxx
@@ -433,7 +433,8 @@ DnsResult::lookupInternal(const Uri& uri)
             else
             {
                // !bwc! Debatable.
-               assert(0);
+               // !anatol! commented the  assert 
+			   // assert(0);
                if (mHandler) mHandler->handle(this);
             }
          }
@@ -464,7 +465,9 @@ void DnsResult::lookupHost(const Data& target)
    }
    else
    {
-      assert(0);
+		// !anatol! commented the assert and called handle
+		// assert(0);
+		if (mHandler) mHandler->handle(this);
    }
 }
 

--- a/resip/stack/HeaderHash.cxx
+++ b/resip/stack/HeaderHash.cxx
@@ -1,5 +1,5 @@
-/* C++ code produced by gperf version 3.0.3 */
-/* Command-line: gperf -D -E -L C++ -t -k '*' --compare-strncmp -Z HeaderHash HeaderHash.gperf  */
+/* C++ code produced by gperf version 3.0.4 */
+/* Command-line: gperf --ignore-case -D -E -L C++ -t -k '*' --compare-strncmp -Z HeaderHash HeaderHash.gperf  */
 
 #if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
       && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
@@ -39,7 +39,52 @@ namespace resip
 using namespace std;
 #line 10 "HeaderHash.gperf"
 struct headers { const char *name; Headers::Type type; };
-/* maximum key range = 430, duplicates = 4 */
+/* maximum key range = 415, duplicates = 4 */
+
+#ifndef GPERF_DOWNCASE
+#define GPERF_DOWNCASE 1
+static unsigned char gperf_downcase[256] =
+  {
+      0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,
+     15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
+     30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,
+     45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,
+     60,  61,  62,  63,  64,  97,  98,  99, 100, 101, 102, 103, 104, 105, 106,
+    107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121,
+    122,  91,  92,  93,  94,  95,  96,  97,  98,  99, 100, 101, 102, 103, 104,
+    105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119,
+    120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134,
+    135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149,
+    150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164,
+    165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179,
+    180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194,
+    195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209,
+    210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224,
+    225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239,
+    240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254,
+    255
+  };
+#endif
+
+#ifndef GPERF_CASE_STRNCMP
+#define GPERF_CASE_STRNCMP 1
+static int
+gperf_case_strncmp (register const char *s1, register const char *s2, register unsigned int n)
+{
+  for (; n > 0;)
+    {
+      unsigned char c1 = gperf_downcase[(unsigned char)*s1++];
+      unsigned char c2 = gperf_downcase[(unsigned char)*s2++];
+      if (c1 != 0 && c1 == c2)
+        {
+          n--;
+          continue;
+        }
+      return (int)c1 - (int)c2;
+    }
+  return 0;
+}
+#endif
 
 class HeaderHash
 {
@@ -54,111 +99,111 @@ HeaderHash::hash (register const char *str, register unsigned int len)
 {
   static unsigned short asso_values[] =
     {
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431,   0, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431,   0,  55,  15,
-        0,  30,  35,  10,   0,  25,   5,  70,  40,  75,
-        0,   5,   0,  25,  10,  50,   0,  10,  45,  15,
-       60,  20,  25, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431, 431, 431, 431, 431,
-      431, 431, 431, 431, 431, 431
+      416, 416, 416, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416,   0, 416, 416, 416, 416,
+      416, 416, 416, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416,   0,  60,  15,  10,  10,
+       30,  30,   5,  35,   0,  75,  40,  70,   0,   5,
+        0,   0,  25,  55,   0,  10,  65,   5,  50,  20,
+       15, 416, 416, 416, 416, 416, 416,   0,  60,  15,
+       10,  10,  30,  30,   5,  35,   0,  75,  40,  70,
+        0,   5,   0,   0,  25,  55,   0,  10,  65,   5,
+       50,  20,  15, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416, 416, 416, 416, 416, 416,
+      416, 416, 416, 416, 416, 416
     };
   register int hval = len;
 
   switch (hval)
     {
       default:
-        hval += asso_values[(unsigned char)tolower(str[24])];
+        hval += asso_values[(unsigned char)str[24]];
       /*FALLTHROUGH*/
       case 24:
-        hval += asso_values[(unsigned char)tolower(str[23])];
+        hval += asso_values[(unsigned char)str[23]];
       /*FALLTHROUGH*/
       case 23:
-        hval += asso_values[(unsigned char)tolower(str[22])];
+        hval += asso_values[(unsigned char)str[22]];
       /*FALLTHROUGH*/
       case 22:
-        hval += asso_values[(unsigned char)tolower(str[21])];
+        hval += asso_values[(unsigned char)str[21]];
       /*FALLTHROUGH*/
       case 21:
-        hval += asso_values[(unsigned char)tolower(str[20])];
+        hval += asso_values[(unsigned char)str[20]];
       /*FALLTHROUGH*/
       case 20:
-        hval += asso_values[(unsigned char)tolower(str[19])];
+        hval += asso_values[(unsigned char)str[19]];
       /*FALLTHROUGH*/
       case 19:
-        hval += asso_values[(unsigned char)tolower(str[18])];
+        hval += asso_values[(unsigned char)str[18]];
       /*FALLTHROUGH*/
       case 18:
-        hval += asso_values[(unsigned char)tolower(str[17])];
+        hval += asso_values[(unsigned char)str[17]];
       /*FALLTHROUGH*/
       case 17:
-        hval += asso_values[(unsigned char)tolower(str[16])];
+        hval += asso_values[(unsigned char)str[16]];
       /*FALLTHROUGH*/
       case 16:
-        hval += asso_values[(unsigned char)tolower(str[15])];
+        hval += asso_values[(unsigned char)str[15]];
       /*FALLTHROUGH*/
       case 15:
-        hval += asso_values[(unsigned char)tolower(str[14])];
+        hval += asso_values[(unsigned char)str[14]];
       /*FALLTHROUGH*/
       case 14:
-        hval += asso_values[(unsigned char)tolower(str[13])];
+        hval += asso_values[(unsigned char)str[13]];
       /*FALLTHROUGH*/
       case 13:
-        hval += asso_values[(unsigned char)tolower(str[12])];
+        hval += asso_values[(unsigned char)str[12]];
       /*FALLTHROUGH*/
       case 12:
-        hval += asso_values[(unsigned char)tolower(str[11])];
+        hval += asso_values[(unsigned char)str[11]];
       /*FALLTHROUGH*/
       case 11:
-        hval += asso_values[(unsigned char)tolower(str[10])];
+        hval += asso_values[(unsigned char)str[10]];
       /*FALLTHROUGH*/
       case 10:
-        hval += asso_values[(unsigned char)tolower(str[9])];
+        hval += asso_values[(unsigned char)str[9]];
       /*FALLTHROUGH*/
       case 9:
-        hval += asso_values[(unsigned char)tolower(str[8])];
+        hval += asso_values[(unsigned char)str[8]];
       /*FALLTHROUGH*/
       case 8:
-        hval += asso_values[(unsigned char)tolower(str[7])];
+        hval += asso_values[(unsigned char)str[7]];
       /*FALLTHROUGH*/
       case 7:
-        hval += asso_values[(unsigned char)tolower(str[6])];
+        hval += asso_values[(unsigned char)str[6]];
       /*FALLTHROUGH*/
       case 6:
-        hval += asso_values[(unsigned char)tolower(str[5])];
+        hval += asso_values[(unsigned char)str[5]];
       /*FALLTHROUGH*/
       case 5:
-        hval += asso_values[(unsigned char)tolower(str[4])];
+        hval += asso_values[(unsigned char)str[4]];
       /*FALLTHROUGH*/
       case 4:
-        hval += asso_values[(unsigned char)tolower(str[3])];
+        hval += asso_values[(unsigned char)str[3]];
       /*FALLTHROUGH*/
       case 3:
-        hval += asso_values[(unsigned char)tolower(str[2])];
+        hval += asso_values[(unsigned char)str[2]];
       /*FALLTHROUGH*/
       case 2:
-        hval += asso_values[(unsigned char)tolower(str[1])];
+        hval += asso_values[(unsigned char)str[1]];
       /*FALLTHROUGH*/
       case 1:
-        hval += asso_values[(unsigned char)tolower(str[0])];
+        hval += asso_values[(unsigned char)str[0]];
         break;
     }
   return hval;
@@ -169,219 +214,227 @@ HeaderHash::in_word_set (register const char *str, register unsigned int len)
 {
   enum
     {
-      TOTAL_KEYWORDS = 104,
+      TOTAL_KEYWORDS = 108,
       MIN_WORD_LENGTH = 1,
       MAX_WORD_LENGTH = 25,
       MIN_HASH_VALUE = 1,
-      MAX_HASH_VALUE = 430
+      MAX_HASH_VALUE = 415
     };
 
   static struct headers wordlist[] =
     {
 #line 20 "HeaderHash.gperf"
       {"t", Headers::To},
-#line 91 "HeaderHash.gperf"
-      {"path", Headers::Path},
 #line 26 "HeaderHash.gperf"
       {"o", Headers::Event},
 #line 36 "HeaderHash.gperf"
       {"to", Headers::To},
-#line 22 "HeaderHash.gperf"
-      {"r", Headers::ReferTo},
+#line 91 "HeaderHash.gperf"
+      {"path", Headers::Path},
+#line 14 "HeaderHash.gperf"
+      {"e", Headers::ContentEncoding},
 #line 16 "HeaderHash.gperf"
       {"c", Headers::ContentType},
 #line 25 "HeaderHash.gperf"
       {"y", Headers::Identity},
-#line 12 "HeaderHash.gperf"
-      {"i", Headers::CallID},
-#line 14 "HeaderHash.gperf"
-      {"e", Headers::ContentEncoding},
 #line 52 "HeaderHash.gperf"
       {"date", Headers::Date},
+#line 22 "HeaderHash.gperf"
+      {"r", Headers::ReferTo},
 #line 17 "HeaderHash.gperf"
       {"f", Headers::From},
-#line 85 "HeaderHash.gperf"
-      {"join", Headers::Join},
-#line 92 "HeaderHash.gperf"
-      {"join", Headers::Join},
+#line 12 "HeaderHash.gperf"
+      {"i", Headers::CallID},
 #line 15 "HeaderHash.gperf"
       {"l", Headers::ContentLength},
 #line 29 "HeaderHash.gperf"
       {"contact", Headers::Contact},
-#line 21 "HeaderHash.gperf"
-      {"v", Headers::Via},
+#line 85 "HeaderHash.gperf"
+      {"join", Headers::Join},
+#line 92 "HeaderHash.gperf"
+      {"join", Headers::Join},
+#line 38 "HeaderHash.gperf"
+      {"accept", Headers::Accept},
+#line 24 "HeaderHash.gperf"
+      {"x", Headers::SessionExpires},
+#line 34 "HeaderHash.gperf"
+      {"route", Headers::Route},
 #line 18 "HeaderHash.gperf"
       {"s", Headers::Subject},
 #line 23 "HeaderHash.gperf"
       {"b", Headers::ReferredBy},
 #line 82 "HeaderHash.gperf"
       {"hide", Headers::UNKNOWN},
-#line 34 "HeaderHash.gperf"
-      {"route", Headers::Route},
-#line 24 "HeaderHash.gperf"
-      {"x", Headers::SessionExpires},
-#line 38 "HeaderHash.gperf"
-      {"accept", Headers::Accept},
-#line 75 "HeaderHash.gperf"
-      {"warning", Headers::Warning},
-#line 19 "HeaderHash.gperf"
-      {"k", Headers::Supported},
-#line 37 "HeaderHash.gperf"
-      {"via", Headers::Via},
+#line 21 "HeaderHash.gperf"
+      {"v", Headers::Via},
 #line 13 "HeaderHash.gperf"
       {"m", Headers::Contact},
+#line 50 "HeaderHash.gperf"
+      {"content-type", Headers::ContentType},
+#line 19 "HeaderHash.gperf"
+      {"k", Headers::Supported},
+#line 27 "HeaderHash.gperf"
+      {"cseq", Headers::CSeq},
 #line 47 "HeaderHash.gperf"
       {"content-id", Headers::ContentId},
-#line 95 "HeaderHash.gperf"
-      {"rack", Headers::RAck},
-#line 96 "HeaderHash.gperf"
-      {"reason", Headers::Reason},
-#line 58 "HeaderHash.gperf"
-      {"priority", Headers::Priority},
-#line 43 "HeaderHash.gperf"
-      {"allow", Headers::Allow},
-#line 83 "HeaderHash.gperf"
-      {"identity", Headers::Identity},
 #line 39 "HeaderHash.gperf"
       {"accept-contact", Headers::AcceptContact},
 #line 81 "HeaderHash.gperf"
       {"event", Headers::Event},
-#line 50 "HeaderHash.gperf"
-      {"content-type", Headers::ContentType},
-#line 63 "HeaderHash.gperf"
-      {"reply-to", Headers::ReplyTo},
-#line 69 "HeaderHash.gperf"
-      {"supported", Headers::Supported},
-#line 80 "HeaderHash.gperf"
-      {"encryption", Headers::UNKNOWN},
-#line 57 "HeaderHash.gperf"
-      {"organization", Headers::Organization},
-#line 78 "HeaderHash.gperf"
-      {"authorization", Headers::Authorization},
 #line 106 "HeaderHash.gperf"
       {"rseq", Headers::RSeq},
-#line 94 "HeaderHash.gperf"
-      {"privacy", Headers::Privacy},
-#line 67 "HeaderHash.gperf"
-      {"sip-etag", Headers::SIPETag},
-#line 27 "HeaderHash.gperf"
-      {"cseq", Headers::CSeq},
-#line 73 "HeaderHash.gperf"
-      {"unsupported", Headers::Unsupported},
-#line 28 "HeaderHash.gperf"
-      {"call-id", Headers::CallID},
-#line 97 "HeaderHash.gperf"
-      {"refer-to",Headers::ReferTo},
-#line 32 "HeaderHash.gperf"
-      {"from", Headers::From},
-#line 62 "HeaderHash.gperf"
-      {"record-route", Headers::RecordRoute},
+#line 43 "HeaderHash.gperf"
+      {"allow", Headers::Allow},
+#line 96 "HeaderHash.gperf"
+      {"reason", Headers::Reason},
+#line 75 "HeaderHash.gperf"
+      {"warning", Headers::Warning},
+#line 37 "HeaderHash.gperf"
+      {"via", Headers::Via},
+#line 119 "HeaderHash.gperf"
+      {"p-conf-party", Headers::PConfParty},
+#line 63 "HeaderHash.gperf"
+      {"reply-to", Headers::ReplyTo},
 #line 100 "HeaderHash.gperf"
       {"reject-contact", Headers::RejectContact},
-#line 53 "HeaderHash.gperf"
-      {"error-info", Headers::ErrorInfo},
-#line 54 "HeaderHash.gperf"
-      {"in-reply-to", Headers::InReplyTo},
-#line 93 "HeaderHash.gperf"
-      {"target-dialog", Headers::TargetDialog},
-#line 30 "HeaderHash.gperf"
-      {"content-length", Headers::ContentLength},
+#line 97 "HeaderHash.gperf"
+      {"refer-to",Headers::ReferTo},
+#line 76 "HeaderHash.gperf"
+      {"www-authenticate",Headers::WWWAuthenticate},
+#line 83 "HeaderHash.gperf"
+      {"identity", Headers::Identity},
+#line 95 "HeaderHash.gperf"
+      {"rack", Headers::RAck},
+#line 80 "HeaderHash.gperf"
+      {"encryption", Headers::UNKNOWN},
 #line 64 "HeaderHash.gperf"
       {"require", Headers::Require},
+#line 69 "HeaderHash.gperf"
+      {"supported", Headers::Supported},
+#line 30 "HeaderHash.gperf"
+      {"content-length", Headers::ContentLength},
+#line 32 "HeaderHash.gperf"
+      {"from", Headers::From},
+#line 73 "HeaderHash.gperf"
+      {"unsupported", Headers::Unsupported},
+#line 67 "HeaderHash.gperf"
+      {"sip-etag", Headers::SIPETag},
+#line 54 "HeaderHash.gperf"
+      {"in-reply-to", Headers::InReplyTo},
+#line 28 "HeaderHash.gperf"
+      {"call-id", Headers::CallID},
+#line 78 "HeaderHash.gperf"
+      {"authorization", Headers::Authorization},
+#line 117 "HeaderHash.gperf"
+      {"p-mref-to", Headers::PMrefTo},
 #line 74 "HeaderHash.gperf"
       {"user-agent", Headers::UserAgent},
 #line 48 "HeaderHash.gperf"
       {"content-encoding", Headers::ContentEncoding},
+#line 62 "HeaderHash.gperf"
+      {"record-route", Headers::RecordRoute},
+#line 58 "HeaderHash.gperf"
+      {"priority", Headers::Priority},
 #line 42 "HeaderHash.gperf"
       {"alert-info",Headers::AlertInfo},
 #line 65 "HeaderHash.gperf"
       {"retry-after", Headers::RetryAfter},
-#line 40 "HeaderHash.gperf"
-      {"accept-encoding", Headers::AcceptEncoding},
-#line 49 "HeaderHash.gperf"
-      {"content-language", Headers::ContentLanguage},
-#line 45 "HeaderHash.gperf"
-      {"call-info", Headers::CallInfo},
-#line 76 "HeaderHash.gperf"
-      {"www-authenticate",Headers::WWWAuthenticate},
 #line 35 "HeaderHash.gperf"
       {"subject", Headers::Subject},
+#line 40 "HeaderHash.gperf"
+      {"accept-encoding", Headers::AcceptEncoding},
+#line 57 "HeaderHash.gperf"
+      {"organization", Headers::Organization},
+#line 99 "HeaderHash.gperf"
+      {"replaces",Headers::Replaces},
+#line 49 "HeaderHash.gperf"
+      {"content-language", Headers::ContentLanguage},
+#line 94 "HeaderHash.gperf"
+      {"privacy", Headers::Privacy},
+#line 53 "HeaderHash.gperf"
+      {"error-info", Headers::ErrorInfo},
+#line 45 "HeaderHash.gperf"
+      {"call-info", Headers::CallInfo},
 #line 41 "HeaderHash.gperf"
       {"accept-language", Headers::AcceptLanguage},
+#line 112 "HeaderHash.gperf"
+      {"min-se", Headers::MinSE},
+#line 118 "HeaderHash.gperf"
+      {"p-conf-policy", Headers::PConfPolicy},
+#line 31 "HeaderHash.gperf"
+      {"expires", Headers::Expires},
 #line 84 "HeaderHash.gperf"
       {"identity-info", Headers::IdentityInfo},
 #line 66 "HeaderHash.gperf"
       {"server", Headers::Server},
-#line 99 "HeaderHash.gperf"
-      {"replaces",Headers::Replaces},
-#line 112 "HeaderHash.gperf"
-      {"min-se", Headers::MinSE},
-#line 115 "HeaderHash.gperf"
-      {"history-info", Headers::HistoryInfo},
+#line 93 "HeaderHash.gperf"
+      {"target-dialog", Headers::TargetDialog},
+#line 71 "HeaderHash.gperf"
+      {"answer-mode", Headers::AnswerMode},
+#line 59 "HeaderHash.gperf"
+      {"proxy-authenticate", Headers::ProxyAuthenticate},
 #line 44 "HeaderHash.gperf"
       {"authentication-info", Headers::AuthenticationInfo},
 #line 88 "HeaderHash.gperf"
       {"p-called-party-id", Headers::PCalledPartyId},
 #line 101 "HeaderHash.gperf"
       {"p-called-party-id", Headers::PCalledPartyId},
-#line 31 "HeaderHash.gperf"
-      {"expires", Headers::Expires},
-#line 60 "HeaderHash.gperf"
-      {"proxy-authorization", Headers::ProxyAuthorization},
 #line 114 "HeaderHash.gperf"
       {"remote-party-id", Headers::RemotePartyId},
-#line 59 "HeaderHash.gperf"
-      {"proxy-authenticate", Headers::ProxyAuthenticate},
-#line 71 "HeaderHash.gperf"
-      {"answer-mode", Headers::AnswerMode},
-#line 87 "HeaderHash.gperf"
-      {"p-associated-uri", Headers::PAssociatedUri},
-#line 102 "HeaderHash.gperf"
-      {"p-associated-uri", Headers::PAssociatedUri},
-#line 68 "HeaderHash.gperf"
-      {"sip-if-match", Headers::SIPIfMatch},
+#line 115 "HeaderHash.gperf"
+      {"history-info", Headers::HistoryInfo},
+#line 61 "HeaderHash.gperf"
+      {"proxy-require", Headers::ProxyRequire},
 #line 113 "HeaderHash.gperf"
       {"refer-sub", Headers::ReferSub},
 #line 98 "HeaderHash.gperf"
       {"referred-by",Headers::ReferredBy},
-#line 61 "HeaderHash.gperf"
-      {"proxy-require", Headers::ProxyRequire},
-#line 46 "HeaderHash.gperf"
-      {"content-disposition", Headers::ContentDisposition},
-#line 89 "HeaderHash.gperf"
-      {"p-media-authorization", Headers::PMediaAuthorization},
-#line 70 "HeaderHash.gperf"
-      {"timestamp", Headers::Timestamp},
 #line 79 "HeaderHash.gperf"
       {"allow-events", Headers::AllowEvents},
-#line 33 "HeaderHash.gperf"
-      {"max-forwards", Headers::MaxForwards},
+#line 70 "HeaderHash.gperf"
+      {"timestamp", Headers::Timestamp},
+#line 60 "HeaderHash.gperf"
+      {"proxy-authorization", Headers::ProxyAuthorization},
+#line 68 "HeaderHash.gperf"
+      {"sip-if-match", Headers::SIPIfMatch},
+#line 87 "HeaderHash.gperf"
+      {"p-associated-uri", Headers::PAssociatedUri},
+#line 102 "HeaderHash.gperf"
+      {"p-associated-uri", Headers::PAssociatedUri},
+#line 90 "HeaderHash.gperf"
+      {"p-preferred-identity", Headers::PPreferredIdentity},
+#line 105 "HeaderHash.gperf"
+      {"response-key", Headers::UNKNOWN},
 #line 103 "HeaderHash.gperf"
       {"service-route", Headers::ServiceRoute},
 #line 110 "HeaderHash.gperf"
       {"service-route", Headers::ServiceRoute},
-#line 90 "HeaderHash.gperf"
-      {"p-preferred-identity", Headers::PPreferredIdentity},
+#line 89 "HeaderHash.gperf"
+      {"p-media-authorization", Headers::PMediaAuthorization},
+#line 46 "HeaderHash.gperf"
+      {"content-disposition", Headers::ContentDisposition},
 #line 107 "HeaderHash.gperf"
       {"security-client", Headers::SecurityClient},
+#line 33 "HeaderHash.gperf"
+      {"max-forwards", Headers::MaxForwards},
 #line 86 "HeaderHash.gperf"
       {"p-asserted-identity", Headers::PAssertedIdentity},
-#line 51 "HeaderHash.gperf"
-      {"content-transfer-encoding", Headers::ContentTransferEncoding},
-#line 105 "HeaderHash.gperf"
-      {"response-key", Headers::UNKNOWN},
-#line 72 "HeaderHash.gperf"
-      {"priv-answer-mode", Headers::PrivAnswerMode},
 #line 55 "HeaderHash.gperf"
       {"min-expires", Headers::MinExpires},
-#line 109 "HeaderHash.gperf"
-      {"security-verify", Headers::SecurityVerify},
-#line 77 "HeaderHash.gperf"
-      {"subscription-state",Headers::SubscriptionState},
-#line 108 "HeaderHash.gperf"
-      {"security-server", Headers::SecurityServer},
+#line 51 "HeaderHash.gperf"
+      {"content-transfer-encoding", Headers::ContentTransferEncoding},
+#line 72 "HeaderHash.gperf"
+      {"priv-answer-mode", Headers::PrivAnswerMode},
+#line 116 "HeaderHash.gperf"
+      {"p-ipcm-extensions", Headers::IPCMExtensions},
 #line 104 "HeaderHash.gperf"
       {"request-disposition", Headers::RequestDisposition},
+#line 109 "HeaderHash.gperf"
+      {"security-verify", Headers::SecurityVerify},
+#line 108 "HeaderHash.gperf"
+      {"security-server", Headers::SecurityServer},
+#line 77 "HeaderHash.gperf"
+      {"subscription-state",Headers::SubscriptionState},
 #line 56 "HeaderHash.gperf"
       {"mime-version", Headers::MIMEVersion},
 #line 111 "HeaderHash.gperf"
@@ -390,60 +443,58 @@ HeaderHash::in_word_set (register const char *str, register unsigned int len)
 
   static short lookup[] =
     {
-        -1,    0,   -1,   -1,    1,   -1,    2,    3,
-        -1,   -1,   -1,    4,   -1,   -1,   -1,   -1,
+        -1,    0,   -1,   -1,   -1,   -1,    1,    2,
+        -1,    3,   -1,    4,   -1,   -1,   -1,   -1,
          5,   -1,   -1,   -1,   -1,    6,   -1,   -1,
-        -1,   -1,    7,   -1,   -1,   -1,   -1,    8,
-        -1,   -1,    9,   -1,   10,   -1,   -1, -148,
-        -1,   13,   14,  -93,   -2,   -1,   15,   -1,
-        -1,   -1,   -1,   16,   -1,   -1,   -1,   -1,
-        17,   -1,   -1,   18,   19,   20,   -1,   -1,
-        -1,   -1,   21,   22,   -1,   -1,   -1,   23,
-        -1,   24,   -1,   -1,   25,   -1,   -1,   -1,
-        -1,   -1,   -1,   -1,   -1,   26,   -1,   -1,
+         7,   -1,    8,   -1,   -1,   -1,   -1,    9,
+        -1,   -1,   -1,   -1,   10,   -1,   -1,   -1,
+        -1,   11,   12,   -1, -156,   -1,   15,  -95,
+        -2,   -1,   -1,   16,   -1,   -1,   -1,   17,
+        18,   -1,   -1,   -1,   -1,   19,   -1,   -1,
+        20,   -1,   21,   -1,   -1,   -1,   -1,   22,
+        23,   -1,   -1,   -1,   24,   -1,   -1,   -1,
+        -1,   -1,   -1,   -1,   25,   26,   -1,   -1,
+        -1,   27,   28,   -1,   -1,   -1,   29,   30,
+        -1,   -1,   -1,   -1,   -1,   31,   32,   33,
+        -1,   -1,   -1,   34,   35,   36,   -1,   -1,
+        -1,   37,   -1,   -1,   38,   -1,   39,   40,
+        41,   -1,   42,   -1,   43,   -1,   -1,   -1,
+        -1,   44,   -1,   -1,   -1,   -1,   45,   -1,
+        46,   -1,   47,   -1,   -1,   -1,   -1,   -1,
+        -1,   -1,   48,   49,   50,   51,   52,   53,
+        54,   55,   -1,   56,   57,   58,   -1,   -1,
+        59,   -1,   60,   61,   -1,   -1,   62,   63,
+        -1,   -1,   64,   -1,   -1,   -1,   65,   66,
+        67,   -1,   68,   -1,   -1,   -1,   -1,   -1,
         -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
-        -1,   -1,   -1,   27,   -1,   28,   -1,   29,
-        -1,   30,   -1,   -1,   31,   32,   33,   -1,
-        34,   35,   36,   37,   -1,   38,   39,   40,
-        -1,   -1,   41,   42,   43,   -1,   44,   45,
-        46,   47,   -1,   -1,   -1,   -1,   -1,   -1,
-        -1,   48,   -1,   49,   50,   51,   -1,   52,
-        53,   -1,   -1,   54,   -1,   -1,   55,   56,
-        -1,   -1,   -1,   57,   58,   -1,   -1,   -1,
-        59,   -1,   -1,   -1,   -1,   -1,   60,   -1,
-        -1,   61,   -1,   62,   63,   -1,   -1,   64,
-        -1,   -1,   65,   -1,   -1,   66,   -1,   67,
-        -1,   -1,   68,   69,   -1,   -1,   -1,   -1,
-        -1,   -1,   70,   -1,   -1, -303,  -33,   -2,
+        69,   70,   -1,   -1,   71,   -1,   72,   -1,
+        -1,   73,   -1,   74,   75,   -1,   -1,   -1,
         -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
-        -1,   -1,   -1,   -1,   73,   -1,   -1,   -1,
-        -1,   -1,   -1,   74,   75,   -1,   -1,   76,
-        -1,   -1,   77,   -1,   -1,   -1,   -1,   -1,
-        -1,   -1,   -1,   -1, -347,   80,   -1,   81,
-        -1,   82,  -26,   -2,   -1,   -1,   -1,   -1,
-        83,   -1,   -1,   -1,   -1,   -1,   84,   -1,
-        85,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
-        86,   -1,   -1,   87,   -1,   -1,   -1,   -1,
-        88, -381,   -1,   91,  -15,   -2,   -1,   -1,
-        -1,   -1,   -1,   -1,   -1,   92,   -1,   -1,
-        -1,   93,   -1,   -1,   -1,   -1,   -1,   94,
-        -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
-        -1,   -1,   -1,   95,   -1,   -1,   -1,   96,
-        -1,   -1,   -1,   -1,   97,   -1,   -1,   -1,
-        -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
-        -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
-        -1,   -1,   -1,   -1,   98,   -1,   -1,   99,
-        -1,   -1,   -1,   -1,   -1,   -1,  100,   -1,
-        -1,   -1,   -1,   -1,   -1,   -1,   -1,  101,
+        -1,   -1,   -1,   -1,   -1,   -1, -332,  -32,
+        -2,   78,   -1,   79,   80,   -1,   -1,   -1,
+        -1,   -1,   81,   -1,   82,   -1,   -1,   -1,
+        -1,   -1,   83,   -1,   -1,   -1,   -1,   -1,
+        -1,   84,   -1,   -1,   -1,   -1,   85,   -1,
+        -1,   86,   -1,   -1,   -1,   -1,   -1,   -1,
+        -1,   -1,   -1,   -1,   -1,   -1,   -1, -381,
+       -21,   -2,   -1,   89,   -1,   90, -388,  -17,
+        -2,   93,   -1,   -1,   94,   95,   -1,   96,
+        -1,   -1,   -1,   -1,   -1,   -1,   97,   -1,
+        -1,   -1,   -1,   -1,   -1,   98,   -1,   -1,
+        -1,   99,   -1,   -1,   -1,   -1,   -1,   -1,
         -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
         -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
-        -1,   -1,   -1,   -1,   -1,   -1,  102,   -1,
+        -1,   -1,   -1,  100,   -1,   -1,   -1,   -1,
         -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
         -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
+        -1,   -1,   -1,   -1,   -1,  101,   -1,   -1,
+        -1,   -1,   -1,   -1,  102,   -1,   -1,   -1,
+        -1,   -1,  103,   -1,   -1,   -1,   -1,  104,
+        -1,   -1,  105,   -1,   -1,   -1,   -1,   -1,
         -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
+       106,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
         -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
-        -1,   -1,   -1,   -1,   -1,   -1,   -1,   -1,
-        -1,   -1,   -1,   -1,   -1,   -1,  103
+        -1,   -1,   -1,   -1,   -1,   -1,   -1,  107
     };
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
@@ -458,7 +509,7 @@ HeaderHash::in_word_set (register const char *str, register unsigned int len)
             {
               register const char *s = wordlist[index].name;
 
-              if (tolower(*str) == *s && !strncasecmp (str + 1, s + 1, len - 1) && s[len] == '\0')
+              if ((((unsigned char)*str ^ (unsigned char)*s) & ~32) == 0 && !gperf_case_strncmp (str, s, len) && s[len] == '\0')
                 return &wordlist[index];
             }
           else if (index < -TOTAL_KEYWORDS)
@@ -471,7 +522,7 @@ HeaderHash::in_word_set (register const char *str, register unsigned int len)
                 {
                   register const char *s = wordptr->name;
 
-                  if (tolower(*str) == *s && !strncasecmp (str + 1, s + 1, len - 1) && s[len] == '\0')
+                  if ((((unsigned char)*str ^ (unsigned char)*s) & ~32) == 0 && !gperf_case_strncmp (str, s, len) && s[len] == '\0')
                     return wordptr;
                   wordptr++;
                 }
@@ -480,6 +531,6 @@ HeaderHash::in_word_set (register const char *str, register unsigned int len)
     }
   return 0;
 }
-#line 116 "HeaderHash.gperf"
+#line 120 "HeaderHash.gperf"
 
 }

--- a/resip/stack/HeaderHash.gperf
+++ b/resip/stack/HeaderHash.gperf
@@ -113,5 +113,9 @@ min-se, Headers::MinSE
 refer-sub, Headers::ReferSub
 remote-party-id, Headers::RemotePartyId
 history-info, Headers::HistoryInfo
+p-ipcm-extensions, Headers::IPCMExtensions
+p-mref-to, Headers::PMrefTo
+p-conf-policy, Headers::PConfPolicy
+p-conf-party, Headers::PConfParty
 %%
 }

--- a/resip/stack/HeaderTypes.hxx
+++ b/resip/stack/HeaderTypes.hxx
@@ -128,6 +128,11 @@ class Headers
          defineMultiHeader(RemotePartyId, "Remote-Party-ID", NameAddr, "draft-ietf-sip-privacy-04"), // ?bwc? Not in 3323, should we keep?
          defineMultiHeader(HistoryInfo, "History-Info", NameAddr, "RFC 4244"),
 
+		 defineHeader(IPCMExtensions, "P-Ipcm-Extensions", Token, "p-ipcm-extensions"),
+		 defineMultiHeader(PMrefTo, "P-Mref-To", NameAddr, "p-ipcm-mcu-multiple-refer-to"),
+		 defineMultiHeader(PConfPolicy, "P-Conf-Policy", Token, "p-ipcm-mcu-conf-policy"),
+		 defineMultiHeader(PConfParty, "P-Conf-Party", NameAddr, "p-ipcm-mcu-conf-party"),
+		  
          defineMultiHeader(RESIP_DO_NOT_USE, "ShouldNotSeeThis", StringCategory, "N/A"),
          MAX_HEADERS,
          NONE

--- a/resip/stack/Headers.cxx
+++ b/resip/stack/Headers.cxx
@@ -285,6 +285,13 @@ defineHeader(RAck, "RAck", RAckCategory, "RFC 3262");
 
 defineMultiHeader(Via, "Via", Via, "RFC 3261");
 
+//alexkr:
+defineHeader(IPCMExtensions, "P-Ipcm-Extensions", Token, "p-ipcm-extensions");
+defineMultiHeader(PMrefTo, "P-Mref-To", NameAddr, "p-ipcm-mcu-multiple-refer-to");
+defineMultiHeader(PConfPolicy, "P-Conf-Policy", Token, "p-ipcm-mcu-conf-policy");
+defineMultiHeader(PConfParty, "P-Conf-Party", NameAddr, "p-ipcm-mcu-conf-party");
+
+
 //Enforces string encoding of extension headers
 Headers::Type                                                          
 H_RESIP_DO_NOT_USEs::getTypeNum() const {return Headers::RESIP_DO_NOT_USE;}                                                                               

--- a/resip/stack/Headers.hxx
+++ b/resip/stack/Headers.hxx
@@ -289,6 +289,12 @@ defineMultiHeader(Via, "Via", Via, "RFC 3261");
 //====================
 defineHeader(RAck, "RAck", RAckCategory, "RFC 3262");
 
+//alexkr:
+defineHeader(IPCMExtensions, "P-Ipcm-Extensions", Token, "p-ipcm-extensions");
+defineMultiHeader(PMrefTo, "P-Mref-To", NameAddr, "p-ipcm-mcu-multiple-refer-to");
+defineMultiHeader(PConfPolicy, "P-Conf-Policy", Token, "p-ipcm-mcu-conf-policy");
+defineMultiHeader(PConfParty, "P-Conf-Party", NameAddr, "p-ipcm-mcu-conf-party");
+	
 //====================
 // special first line accessors
 //====================

--- a/resip/stack/Helper.hxx
+++ b/resip/stack/Helper.hxx
@@ -521,6 +521,8 @@ class Helper
       // the tree.
       static std::auto_ptr<SdpContents> getSdp(Contents* tree);
 
+	  static void setCallidHostPart(const Data& hostPart);
+
    private:
       static Data qopOption(const Auth& challenge);
       class NonceHelperPtr
@@ -531,6 +533,7 @@ class Helper
             NonceHelper *mNonceHelper;
       };
       static NonceHelperPtr mNonceHelperPtr;
+	  static Data mCallidHostPart;
 };
 
 }

--- a/resip/stack/Mime.cxx
+++ b/resip/stack/Mime.cxx
@@ -70,15 +70,15 @@ Mime::operator<(const Mime& rhs) const
 bool
 Mime::isEqual(const Mime& rhs) const
 {
-   return (isEqualNoCase(type(), rhs.type()) &&
-           isEqualNoCase(subType(), rhs.subType()));
+   return (::isEqualNoCase(type(), rhs.type()) &&
+           ::isEqualNoCase(subType(), rhs.subType()));
 }
 
 bool
 Mime::operator==(const Mime& rhs) const
 {
-   return (isEqualNoCase(type(), rhs.type()) &&
-           isEqualNoCase(subType(), rhs.subType()));
+   return (::isEqualNoCase(type(), rhs.type()) &&
+           ::isEqualNoCase(subType(), rhs.subType()));
 }
 
 bool

--- a/resip/stack/Mime.hxx
+++ b/resip/stack/Mime.hxx
@@ -28,6 +28,11 @@ class Mime : public ParserCategory
       Mime& operator=(const Mime&);
       bool operator<(const Mime& rhs) const;
       bool isEqual(const Mime& rhs) const;
+      bool isEqualNoCase(const Mime& rhs) const
+      {
+          return isEqual(rhs);
+      }
+
       bool operator==(const Mime& rhs) const;
       bool operator!=(const Mime& rhs) const;
       

--- a/resip/stack/MsgHeaderScanner.cxx
+++ b/resip/stack/MsgHeaderScanner.cxx
@@ -181,7 +181,10 @@ struct TransitionInfo
 
 static TransitionInfo stateMachine[numStates][numCharCategories];
 
-inline void specTransition(State state,
+#ifndef __APPLE__
+inline
+#endif
+void specTransition(State state,
                            CharCategory charCategory,
                            TransitionAction action,
                            State nextState)
@@ -956,7 +959,7 @@ MsgHeaderScanner::scanChunk(char * chunk,
          case taTermStatusLine:
             if (!processMsgHeaderStatusLine(mMsg,
                                             textStartCharPtr,
-                                            charPtr - textStartCharPtr,
+                                            static_cast<unsigned int>(charPtr - textStartCharPtr),
                                             localTextPropBitMask))
             {
                result = MsgHeaderScanner::scrError;
@@ -967,7 +970,7 @@ MsgHeaderScanner::scanChunk(char * chunk,
             break;
          case taTermFieldName:
          {
-            mFieldNameLength = charPtr - textStartCharPtr;
+            mFieldNameLength = static_cast<unsigned int>(charPtr - textStartCharPtr);
             bool isMultiValueAllowed;
             lookupMsgHeaderFieldInfo(textStartCharPtr,
                                      &mFieldNameLength,
@@ -997,7 +1000,7 @@ MsgHeaderScanner::scanChunk(char * chunk,
                                               mFieldName,
                                               mFieldNameLength,
                                               textStartCharPtr,
-                                              (charPtr - textStartCharPtr) - 2,
+                                              static_cast<unsigned int>(charPtr - textStartCharPtr) - 2,
                                               localTextPropBitMask);       //^:CRLF
             goto performStartTextAction;
          case taTermValue:
@@ -1006,7 +1009,7 @@ MsgHeaderScanner::scanChunk(char * chunk,
                                               mFieldName,
                                               mFieldNameLength,
                                               textStartCharPtr,
-                                              charPtr - textStartCharPtr,
+                                              static_cast<unsigned int>(charPtr - textStartCharPtr),
                                               localTextPropBitMask);
             textStartCharPtr = 0;
             break;
@@ -1032,7 +1035,7 @@ MsgHeaderScanner::scanChunk(char * chunk,
                }
                else
                {
-                  mPrevScanChunkNumSavedTextChars = termCharPtr - textStartCharPtr;
+                  mPrevScanChunkNumSavedTextChars = static_cast<int>(termCharPtr - textStartCharPtr);
                }
                mTextPropBitMask = localTextPropBitMask;
                result = MsgHeaderScanner::scrNextChunk;

--- a/resip/stack/NameAddr.cxx
+++ b/resip/stack/NameAddr.cxx
@@ -228,6 +228,8 @@ NameAddr::parse(ParseBuffer& pb)
                case ParameterTypes::transport:
                case ParameterTypes::ttl:
                case ParameterTypes::user:
+					//alexkr
+			   case ParameterTypes::orbit:				
                {
                   mUri.mParameters.push_back(*it);
                   it = mParameters.erase(it);

--- a/resip/stack/Parameter.hxx
+++ b/resip/stack/Parameter.hxx
@@ -21,6 +21,9 @@ class Parameter
 
       virtual Parameter* clone() const = 0;
 
+	//alexkr: 2check
+	virtual bool bad() const {return false;}
+	
       virtual EncodeStream& encode(EncodeStream& stream) const = 0;
 
       virtual bool isQuoted() const { return false; } // only on DataParameter

--- a/resip/stack/ParameterHash.cxx
+++ b/resip/stack/ParameterHash.cxx
@@ -1,5 +1,5 @@
-/* C++ code produced by gperf version 3.0.4 */
-/* Command-line: gperf -D -E -L C++ -t -k '*' --compare-strncmp -Z ParameterHash ParameterHash.gperf  */
+/* C++ code produced by gperf version 3.0.3 */
+/* Command-line: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/gperf -D -E -L C++ -t -k '*' --compare-strncmp -Z ParameterHash ParameterHash.gperf  */
 
 #if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
       && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
@@ -37,7 +37,7 @@ namespace resip {
 using namespace std;
 #line 8 "ParameterHash.gperf"
 struct params { const char *name; ParameterTypes::Type type; };
-/* maximum key range = 266, duplicates = 0 */
+/* maximum key range = 313, duplicates = 0 */
 
 class ParameterHash
 {
@@ -52,34 +52,34 @@ ParameterHash::hash (register const char *str, register unsigned int len)
 {
   static unsigned short asso_values[] =
     {
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268,   0, 268,  40,   0, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268,   0,  25,   0,
-       15,   0,  15,  35,  75,  10, 268,   0,   0,  25,
-        5,   5,   5,  45,   0,   0,   0,  40,  85,   0,
-       65,  65,  40, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268, 268, 268, 268, 268,
-      268, 268, 268, 268, 268, 268
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318,  10, 318,   5,   5, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318,   0,  85,   0,
+       15,   5,  60,  40,  15,   0,   0,   0,  20,   0,
+        5,   0,  35, 100,   0,  20,   0,   5,  45,   0,
+       85,  35,  25, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318, 318, 318, 318, 318,
+      318, 318, 318, 318, 318, 318
     };
-  register int hval = len;
+  register unsigned int hval = len;
 
   switch (hval)
     {
@@ -131,222 +131,239 @@ ParameterHash::in_word_set (register const char *str, register unsigned int len)
 {
   enum
     {
-      TOTAL_KEYWORDS = 88,
+      TOTAL_KEYWORDS = 95,
       MIN_WORD_LENGTH = 1,
       MAX_WORD_LENGTH = 13,
-      MIN_HASH_VALUE = 2,
-      MAX_HASH_VALUE = 267
+      MIN_HASH_VALUE = 5,
+      MAX_HASH_VALUE = 317
     };
 
   static struct params wordlist[] =
     {
-#line 39 "ParameterHash.gperf"
-      {"lr", ParameterTypes::lr},
-#line 37 "ParameterHash.gperf"
-      {"ttl", ParameterTypes::ttl},
-#line 62 "ParameterHash.gperf"
-      {"stale", ParameterTypes::stale},
-#line 58 "ParameterHash.gperf"
-      {"nc", ParameterTypes::nc},
 #line 23 "ParameterHash.gperf"
       {"actor", ParameterTypes::actor},
-#line 81 "ParameterHash.gperf"
-      {"site", ParameterTypes::site},
-#line 52 "ParameterHash.gperf"
-      {"rport", ParameterTypes::rport},
-#line 69 "ParameterHash.gperf"
-      {"reason", ParameterTypes::reason},
+#line 58 "ParameterHash.gperf"
+      {"nc", ParameterTypes::nc},
+#line 67 "ParameterHash.gperf"
+      {"uri", ParameterTypes::uri},
+#line 101 "ParameterHash.gperf"
+      {"cterm", ParameterTypes::cterm},
+#line 32 "ParameterHash.gperf"
+      {"name", ParameterTypes::name},
+#line 56 "ParameterHash.gperf"
+      {"id", ParameterTypes::id},
 #line 10 "ParameterHash.gperf"
       {"data", ParameterTypes::data},
 #line 57 "ParameterHash.gperf"
       {"nonce", ParameterTypes::nonce},
 #line 54 "ParameterHash.gperf"
       {"cnonce", ParameterTypes::cnonce},
-#line 11 "ParameterHash.gperf"
-      {"control", ParameterTypes::control},
-#line 61 "ParameterHash.gperf"
-      {"response", ParameterTypes::response},
-#line 33 "ParameterHash.gperf"
-      {"transport", ParameterTypes::transport},
-#line 56 "ParameterHash.gperf"
-      {"id", ParameterTypes::id},
-#line 75 "ParameterHash.gperf"
-      {"protocol", ParameterTypes::protocol},
-#line 50 "ParameterHash.gperf"
-      {"rinstance", ParameterTypes::rinstance},
+#line 39 "ParameterHash.gperf"
+      {"lr", ParameterTypes::lr},
+#line 37 "ParameterHash.gperf"
+      {"ttl", ParameterTypes::ttl},
+#line 83 "ParameterHash.gperf"
+      {"mode", ParameterTypes::mode},
+#line 55 "ParameterHash.gperf"
+      {"domain", ParameterTypes::domain},
+#line 95 "ParameterHash.gperf"
+      {"url", ParameterTypes::url},
+#line 81 "ParameterHash.gperf"
+      {"site", ParameterTypes::site},
 #line 60 "ParameterHash.gperf"
       {"realm", ParameterTypes::realm},
-#line 28 "ParameterHash.gperf"
-      {"ob", ParameterTypes::ob},
-#line 32 "ParameterHash.gperf"
-      {"name", ParameterTypes::name},
+#line 99 "ParameterHash.gperf"
+      {"joined", ParameterTypes::joined},
+#line 11 "ParameterHash.gperf"
+      {"control", ParameterTypes::control},
+#line 44 "ParameterHash.gperf"
+      {"duration", ParameterTypes::duration},
+#line 34 "ParameterHash.gperf"
+      {"user", ParameterTypes::user},
+#line 38 "ParameterHash.gperf"
+      {"maddr", ParameterTypes::maddr},
+#line 69 "ParameterHash.gperf"
+      {"reason", ParameterTypes::reason},
+#line 92 "ParameterHash.gperf"
+      {"document", ParameterTypes::document},
+#line 51 "ParameterHash.gperf"
+      {"comp", ParameterTypes::comp},
+#line 52 "ParameterHash.gperf"
+      {"rport", ParameterTypes::rport},
+#line 36 "ParameterHash.gperf"
+      {"method", ParameterTypes::method},
 #line 29 "ParameterHash.gperf"
       {"gr", ParameterTypes::gr},
 #line 47 "ParameterHash.gperf"
       {"tag", ParameterTypes::tag},
-#line 51 "ParameterHash.gperf"
-      {"comp", ParameterTypes::comp},
-#line 95 "ParameterHash.gperf"
-      {"url", ParameterTypes::url},
-#line 34 "ParameterHash.gperf"
-      {"user", ParameterTypes::user},
-#line 40 "ParameterHash.gperf"
-      {"q", ParameterTypes::q},
-#line 26 "ParameterHash.gperf"
-      {"+sip.instance", ParameterTypes::Instance},
-#line 83 "ParameterHash.gperf"
-      {"mode", ParameterTypes::mode},
+#line 50 "ParameterHash.gperf"
+      {"rinstance", ParameterTypes::rinstance},
 #line 89 "ParameterHash.gperf"
       {"model", ParameterTypes::model},
-#line 18 "ParameterHash.gperf"
-      {"application", ParameterTypes::application},
-#line 67 "ParameterHash.gperf"
-      {"uri", ParameterTypes::uri},
+#line 85 "ParameterHash.gperf"
+      {"charset", ParameterTypes::charset},
+#line 63 "ParameterHash.gperf"
+      {"username", ParameterTypes::username},
+#line 103 "ParameterHash.gperf"
+      {"hadd", ParameterTypes::hadd},
+#line 62 "ParameterHash.gperf"
+      {"stale", ParameterTypes::stale},
+#line 42 "ParameterHash.gperf"
+      {"to-tag", ParameterTypes::toTag},
 #line 79 "ParameterHash.gperf"
       {"size", ParameterTypes::size},
-#line 97 "ParameterHash.gperf"
-      {"addtransport", ParameterTypes::addTransport},
-#line 66 "ParameterHash.gperf"
-      {"qop", ParameterTypes::qop},
-#line 38 "ParameterHash.gperf"
-      {"maddr", ParameterTypes::maddr},
+#line 94 "ParameterHash.gperf"
+      {"network-user", ParameterTypes::networkUser},
+#line 104 "ParameterHash.gperf"
+      {"hdel", ParameterTypes::hdel},
+#line 16 "ParameterHash.gperf"
+      {"methods", ParameterTypes::methods},
+#line 75 "ParameterHash.gperf"
+      {"protocol", ParameterTypes::protocol},
+#line 82 "ParameterHash.gperf"
+      {"directory", ParameterTypes::directory},
+#line 76 "ParameterHash.gperf"
+      {"micalg", ParameterTypes::micalg},
+#line 33 "ParameterHash.gperf"
+      {"transport", ParameterTypes::transport},
+#line 19 "ParameterHash.gperf"
+      {"video", ParameterTypes::video},
+#line 27 "ParameterHash.gperf"
+      {"reg-id", ParameterTypes::regid},
+#line 17 "ParameterHash.gperf"
+      {"schemes", ParameterTypes::schemes},
+#line 72 "ParameterHash.gperf"
+      {"d-ver", ParameterTypes::dVer},
+#line 88 "ParameterHash.gperf"
+      {"vendor", ParameterTypes::vendor},
+#line 15 "ParameterHash.gperf"
+      {"priority", ParameterTypes::priority},
+#line 21 "ParameterHash.gperf"
+      {"type", ParameterTypes::type},
+#line 102 "ParameterHash.gperf"
+      {"ctype", ParameterTypes::ctype},
+#line 84 "ParameterHash.gperf"
+      {"server", ParameterTypes::server},
+#line 90 "ParameterHash.gperf"
+      {"version", ParameterTypes::version},
+#line 49 "ParameterHash.gperf"
+      {"received", ParameterTypes::received},
+#line 53 "ParameterHash.gperf"
+      {"algorithm", ParameterTypes::algorithm},
+#line 70 "ParameterHash.gperf"
+      {"d-alg", ParameterTypes::dAlg},
+#line 14 "ParameterHash.gperf"
+      {"events", ParameterTypes::events},
+#line 28 "ParameterHash.gperf"
+      {"ob", ParameterTypes::ob},
+#line 100 "ParameterHash.gperf"
+      {"left", ParameterTypes::left},
+#line 98 "ParameterHash.gperf"
+      {"orbit", ParameterTypes::orbit},
 #line 13 "ParameterHash.gperf"
       {"description", ParameterTypes::description},
-#line 41 "ParameterHash.gperf"
-      {"purpose", ParameterTypes::purpose},
-#line 74 "ParameterHash.gperf"
-      {"filename", ParameterTypes::filename},
-#line 55 "ParameterHash.gperf"
-      {"domain", ParameterTypes::domain},
 #line 35 "ParameterHash.gperf"
       {"ext", ParameterTypes::extension},
 #line 24 "ParameterHash.gperf"
       {"text", ParameterTypes::text},
 #line 80 "ParameterHash.gperf"
       {"permission", ParameterTypes::permission},
-#line 21 "ParameterHash.gperf"
-      {"type", ParameterTypes::type},
-#line 76 "ParameterHash.gperf"
-      {"micalg", ParameterTypes::micalg},
-#line 22 "ParameterHash.gperf"
-      {"isfocus", ParameterTypes::isFocus},
-#line 63 "ParameterHash.gperf"
-      {"username", ParameterTypes::username},
 #line 93 "ParameterHash.gperf"
       {"app-id", ParameterTypes::appId},
-#line 85 "ParameterHash.gperf"
-      {"charset", ParameterTypes::charset},
-#line 44 "ParameterHash.gperf"
-      {"duration", ParameterTypes::duration},
-#line 42 "ParameterHash.gperf"
-      {"to-tag", ParameterTypes::toTag},
-#line 45 "ParameterHash.gperf"
-      {"expires", ParameterTypes::expires},
-#line 84 "ParameterHash.gperf"
-      {"server", ParameterTypes::server},
-#line 70 "ParameterHash.gperf"
-      {"d-alg", ParameterTypes::dAlg},
-#line 14 "ParameterHash.gperf"
-      {"events", ParameterTypes::events},
-#line 92 "ParameterHash.gperf"
-      {"document", ParameterTypes::document},
-#line 65 "ParameterHash.gperf"
-      {"refresher", ParameterTypes::refresher},
-#line 25 "ParameterHash.gperf"
-      {"extensions", ParameterTypes::extensions},
-#line 59 "ParameterHash.gperf"
-      {"opaque", ParameterTypes::opaque},
-#line 94 "ParameterHash.gperf"
-      {"network-user", ParameterTypes::networkUser},
-#line 15 "ParameterHash.gperf"
-      {"priority", ParameterTypes::priority},
-#line 82 "ParameterHash.gperf"
-      {"directory", ParameterTypes::directory},
-#line 27 "ParameterHash.gperf"
-      {"reg-id", ParameterTypes::regid},
-#line 17 "ParameterHash.gperf"
-      {"schemes", ParameterTypes::schemes},
-#line 78 "ParameterHash.gperf"
-      {"expiration", ParameterTypes::expiration},
-#line 48 "ParameterHash.gperf"
-      {"branch", ParameterTypes::branch},
-#line 90 "ParameterHash.gperf"
-      {"version", ParameterTypes::version},
-#line 71 "ParameterHash.gperf"
-      {"d-qop", ParameterTypes::dQop},
-#line 88 "ParameterHash.gperf"
-      {"vendor", ParameterTypes::vendor},
-#line 49 "ParameterHash.gperf"
-      {"received", ParameterTypes::received},
-#line 19 "ParameterHash.gperf"
-      {"video", ParameterTypes::video},
-#line 86 "ParameterHash.gperf"
-      {"access-type", ParameterTypes::accessType},
-#line 20 "ParameterHash.gperf"
-      {"language", ParameterTypes::language},
-#line 36 "ParameterHash.gperf"
-      {"method", ParameterTypes::method},
-#line 16 "ParameterHash.gperf"
-      {"methods", ParameterTypes::methods},
-#line 43 "ParameterHash.gperf"
-      {"from-tag", ParameterTypes::fromTag},
-#line 68 "ParameterHash.gperf"
-      {"retry-after", ParameterTypes::retryAfter},
-#line 72 "ParameterHash.gperf"
-      {"d-ver", ParameterTypes::dVer},
-#line 12 "ParameterHash.gperf"
-      {"mobility", ParameterTypes::mobility},
-#line 46 "ParameterHash.gperf"
-      {"handling", ParameterTypes::handling},
-#line 96 "ParameterHash.gperf"
-      {"sigcomp-id", ParameterTypes::sigcompId},
-#line 87 "ParameterHash.gperf"
-      {"profile-type", ParameterTypes::profileType},
-#line 53 "ParameterHash.gperf"
-      {"algorithm", ParameterTypes::algorithm},
-#line 77 "ParameterHash.gperf"
-      {"boundary", ParameterTypes::boundary},
-#line 73 "ParameterHash.gperf"
-      {"smime-type", ParameterTypes::smimeType},
-#line 64 "ParameterHash.gperf"
-      {"early-only", ParameterTypes::earlyOnly},
+#line 61 "ParameterHash.gperf"
+      {"response", ParameterTypes::response},
+#line 40 "ParameterHash.gperf"
+      {"q", ParameterTypes::q},
+#line 97 "ParameterHash.gperf"
+      {"addtransport", ParameterTypes::addTransport},
+#line 74 "ParameterHash.gperf"
+      {"filename", ParameterTypes::filename},
 #line 31 "ParameterHash.gperf"
       {"temp-gruu", ParameterTypes::tempGruu},
+#line 18 "ParameterHash.gperf"
+      {"application", ParameterTypes::application},
+#line 41 "ParameterHash.gperf"
+      {"purpose", ParameterTypes::purpose},
+#line 46 "ParameterHash.gperf"
+      {"handling", ParameterTypes::handling},
+#line 48 "ParameterHash.gperf"
+      {"branch", ParameterTypes::branch},
+#line 22 "ParameterHash.gperf"
+      {"isfocus", ParameterTypes::isFocus},
+#line 43 "ParameterHash.gperf"
+      {"from-tag", ParameterTypes::fromTag},
+#line 73 "ParameterHash.gperf"
+      {"smime-type", ParameterTypes::smimeType},
+#line 26 "ParameterHash.gperf"
+      {"+sip.instance", ParameterTypes::Instance},
+#line 65 "ParameterHash.gperf"
+      {"refresher", ParameterTypes::refresher},
+#line 68 "ParameterHash.gperf"
+      {"retry-after", ParameterTypes::retryAfter},
+#line 20 "ParameterHash.gperf"
+      {"language", ParameterTypes::language},
+#line 96 "ParameterHash.gperf"
+      {"sigcomp-id", ParameterTypes::sigcompId},
+#line 64 "ParameterHash.gperf"
+      {"early-only", ParameterTypes::earlyOnly},
+#line 86 "ParameterHash.gperf"
+      {"access-type", ParameterTypes::accessType},
+#line 66 "ParameterHash.gperf"
+      {"qop", ParameterTypes::qop},
+#line 78 "ParameterHash.gperf"
+      {"expiration", ParameterTypes::expiration},
+#line 12 "ParameterHash.gperf"
+      {"mobility", ParameterTypes::mobility},
+#line 59 "ParameterHash.gperf"
+      {"opaque", ParameterTypes::opaque},
+#line 77 "ParameterHash.gperf"
+      {"boundary", ParameterTypes::boundary},
+#line 25 "ParameterHash.gperf"
+      {"extensions", ParameterTypes::extensions},
+#line 45 "ParameterHash.gperf"
+      {"expires", ParameterTypes::expires},
+#line 71 "ParameterHash.gperf"
+      {"d-qop", ParameterTypes::dQop},
 #line 30 "ParameterHash.gperf"
       {"pub-gruu", ParameterTypes::pubGruu},
+#line 87 "ParameterHash.gperf"
+      {"profile-type", ParameterTypes::profileType},
 #line 91 "ParameterHash.gperf"
       {"effective-by", ParameterTypes::effectiveBy}
     };
 
   static signed char lookup[] =
     {
-      -1, -1,  0,  1, -1,  2, -1,  3, -1, -1,  4, -1, -1, -1,
-       5,  6,  7, -1, -1,  8,  9, 10, 11, 12, 13, -1, -1, 14,
-      15, 16, 17, -1, 18, -1, 19, -1, -1, 20, 21, 22, -1, -1,
-      -1, 23, 24, -1, 25, -1, 26, 27, 28, 29, -1, 30, 31, -1,
-      -1, 32, 33, -1, 34, 35, 36, 37, -1, -1, 38, -1, 39, 40,
-      41, -1, -1, -1, 42, -1, 43, 44, 45, -1, -1, 46, 47, 48,
-      -1, -1, 49, 50, -1, -1, -1, 51, -1, -1, -1, 52, 53, -1,
-      54, 55, 56, 57, 58, 59, 60, -1, 61, 62, -1, -1, 63, 64,
-      65, -1, -1, 66, 67, -1, 68, -1, 69, 70, -1, 71, -1, -1,
-      72, 73, 74, -1, -1, 75, -1, -1, -1, -1, -1, -1, -1, -1,
-      -1, -1, -1, -1, -1, 76, -1, -1, 77, -1, -1, -1, -1, 78,
-      -1, 79, -1, 80, -1, 81, -1, -1, -1, 82, -1, -1, -1, -1,
-      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 83, -1,
-      -1, -1, -1, -1, -1, -1, -1, -1, 84, -1, -1, -1, 85, -1,
+      -1, -1, -1, -1, -1,  0, -1,  1,  2, -1,  3, -1, -1, -1,
+       4, -1, -1,  5, -1,  6,  7,  8,  9, 10, 11, -1, 12, -1,
+      13, 14, 15, 16, 17, 18, 19, 20, 21, -1, 22, 23, 24, 25,
+      26, 27, 28, 29, -1, 30, 31, 32, 33, 34, -1, -1, 35, -1,
+      -1, 36, -1, 37, -1, -1, 38, 39, 40, -1, 41, -1, -1, 42,
+      43, 44, 45, -1, -1, 46, 47, -1, 48, 49, 50, 51, 52, 53,
+      54, 55, 56, 57, -1, 58, 59, 60, -1, 61, 62, 63, 64, -1,
+      65, -1, -1, 66, 67, 68, 69, -1, 70, 71, 72, -1, -1, 73,
+      74, 75, -1, 76, -1, -1, 77, 78, -1, 79, -1, 80, -1, 81,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, 82, 83, -1, 84, -1,
+      85, -1, -1, -1, -1, -1, -1, -1, 86, -1, -1, 87, -1, 88,
+      -1, 89, -1, 90, -1, -1, 91, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, 92, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, 93, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
       -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
       -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-      -1, -1, -1, -1, -1, -1, -1, -1, -1, 86, -1, -1, -1, -1,
       -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
       -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-      -1, 87
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, 94
     };
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
     {
-      register int key = hash (str, len);
+      unsigned int key = hash (str, len);
 
-      if (key <= MAX_HASH_VALUE && key >= 0)
+      if (key <= MAX_HASH_VALUE)
         {
           register int index = lookup[key];
 
@@ -361,6 +378,6 @@ ParameterHash::in_word_set (register const char *str, register unsigned int len)
     }
   return 0;
 }
-#line 98 "ParameterHash.gperf"
+#line 105 "ParameterHash.gperf"
 
 }

--- a/resip/stack/ParameterHash.gperf
+++ b/resip/stack/ParameterHash.gperf
@@ -95,5 +95,12 @@ network-user, ParameterTypes::networkUser
 url, ParameterTypes::url
 sigcomp-id, ParameterTypes::sigcompId
 addtransport, ParameterTypes::addTransport
+orbit, ParameterTypes::orbit
+joined, ParameterTypes::joined
+left, ParameterTypes::left
+cterm, ParameterTypes::cterm
+ctype, ParameterTypes::ctype
+hadd, ParameterTypes::hadd
+hdel, ParameterTypes::hdel
 %%
 }

--- a/resip/stack/ParameterTypeEnums.hxx
+++ b/resip/stack/ParameterTypeEnums.hxx
@@ -121,6 +121,15 @@ class ParameterTypes
          defineParam(qop, "qop", DataParameter, "RFC 3261"),
          defineParam(qopOptions, "qop", DataParameter, "RFC 3261"),
          defineParam(addTransport, "addTransport", ExistsParameter, ""),
+		  //alexkr
+		  defineParam(orbit, "orbit", DataParameter, "Polycom parking orbit implementation"),
+		  defineParam(joined, "joined", ExistsParameter, "MCU joined notification"),
+		  defineParam(left, "left", ExistsParameter, "MCU left notification"),
+		  defineParam(cterm, "cterm", DataParameter, "MCU termination policy"),
+		  defineParam(ctype, "ctype", DataParameter, "MCU termination type"),
+		  defineParam(hadd, "hadd", DataParameter, "MCU host address add"),
+		  defineParam(hdel, "hdel", DataParameter, "MCU host address delete"),
+		  
 
          MAX_PARAMETER
       };

--- a/resip/stack/ParameterTypes.cxx
+++ b/resip/stack/ParameterTypes.cxx
@@ -120,6 +120,15 @@ defineParam(qop,"qop",DataParameter,"RFC3261");
 defineParam(qopOptions,"qop",DataParameter,"RFC3261");
 
 defineParam(addTransport, "addTransport", ExistsParameter, "");
+//alexkr
+defineParam(orbit, "orbit", DataParameter, "Polycom parking orbit implementation");
+defineParam(joined, "joined", ExistsParameter, "MCU joined notification");
+defineParam(left, "left", ExistsParameter, "MCU left notification");
+defineParam(cterm, "cterm", DataParameter, "MCU termination policy");
+defineParam(ctype, "ctype", DataParameter, "MCU termination type");
+defineParam(hadd, "hadd", DataParameter, "MCU host address add");
+defineParam(hdel, "hdel", DataParameter, "MCU host address delete");
+
 
 #include "resip/stack/ParameterHash.hxx"
 

--- a/resip/stack/ParameterTypes.hxx
+++ b/resip/stack/ParameterTypes.hxx
@@ -132,6 +132,15 @@ defineParam(qop,"qop",DataParameter,"RFC3261");
 defineParam(qopOptions,"qop",DataParameter,"RFC3261");
 defineParam(addTransport, "addTransport", ExistsParameter, "RESIP INTERNAL");
 
+//alexkr
+defineParam(orbit, "orbit", DataParameter, "Polycom parking orbit implementation");
+defineParam(joined, "joined", ExistsParameter, "MCU joined notification");
+defineParam(left, "left", ExistsParameter, "MCU left notification");
+defineParam(cterm, "cterm", DataParameter, "MCU termination policy");
+defineParam(ctype, "ctype", DataParameter, "MCU termination type");
+defineParam(hadd, "hadd", DataParameter, "MCU host address add");
+defineParam(hdel, "hdel", DataParameter, "MCU host address delete");
+	
 }
 
 #undef defineParam

--- a/resip/stack/ParserCategory.hxx
+++ b/resip/stack/ParserCategory.hxx
@@ -168,6 +168,16 @@ class ParserCategory : public LazyParser
 
       defineParam(sigcompId, "sigcomp-id", QuotedDataParameter, "draft-ietf-rohc-sigcomp-sip");
       defineParam(addTransport, "addTransport", ExistsParameter, "");
+	
+		//alexkr
+		defineParam(orbit, "orbit", DataParameter, "Polycom parking orbit implementation");
+		defineParam(joined, "joined", ExistsParameter, "MCU joined notification");
+		defineParam(left, "left", ExistsParameter, "MCU left notification");
+		defineParam(cterm, "cterm", DataParameter, "MCU termination policy");
+		defineParam(ctype, "ctype", DataParameter, "MCU termination type");
+		defineParam(hadd, "hadd", DataParameter, "MCU host address add");
+		defineParam(hdel, "hdel", DataParameter, "MCU host address delete");
+	
 
       void parseParameters(ParseBuffer& pb);
       EncodeStream& encodeParameters(EncodeStream& str) const;
@@ -180,6 +190,10 @@ class ParserCategory : public LazyParser
       void removeParameterByEnum(ParameterTypes::Type type);
       void setParameter(const Parameter* parameter);
 
+	//alexkr: 2check
+	void removeParameterByData(const Data& data);
+	
+
       int numKnownParams() const {return (int)mParameters.size();};
       int numUnknownParams() const {return (int)mUnknownParameters.size();};
 
@@ -187,7 +201,6 @@ class ParserCategory : public LazyParser
       ParserCategory();
 
       Parameter* getParameterByData(const Data& data) const;
-      void removeParameterByData(const Data& data);
 
       virtual const Data& errorContext() const;
 

--- a/resip/stack/ParserContainer.hxx
+++ b/resip/stack/ParserContainer.hxx
@@ -25,7 +25,6 @@ class ParserContainer : public ParserContainerBase
       typedef const value_type* const_pointer;
       typedef value_type& reference;
       typedef const value_type& const_reference;
-      typedef ptrdiff_t difference_type;
 
       ParserContainer()
          : ParserContainerBase(Headers::UNKNOWN)
@@ -134,7 +133,7 @@ class ParserContainer : public ParserContainerBase
               i != mParsers.end(); ++i)
          {
             // operator== defined by default, but often not usefully
-            if (rhs.isEqual(*static_cast<T*>(*i)))
+            if (rhs.isEqualNoCase(*static_cast<T*>(*i)))
             {
                return true;
             }

--- a/resip/stack/SdpContents.cxx
+++ b/resip/stack/SdpContents.cxx
@@ -1771,6 +1771,8 @@ Codec::parse(ParseBuffer& pb,
       pb.data(mEncodingParameters, anchor);
    }
    mPayloadType = payloadType;
+	mName.c_str();  // alexei - Data::own();	
+	mEncodingParameters.c_str(); // anatol - Data::own();	
 
    assignFormatParameters(medium); 
 }
@@ -1793,6 +1795,7 @@ Codec::assignFormatParameters(const SdpContents::Session::Medium& medium)
                const char* anchor = pb.skipWhitespace();
                pb.skipToEnd();
                pb.data(mParameters, anchor);
+			   mParameters.c_str(); // anatol - Data::own();	
                break;
             }
          }
@@ -1862,7 +1865,8 @@ bool
 resip::operator==(const Codec& lhs, const Codec& rhs)
 {
    static Data defaultEncodingParameters(Data("1"));  // Default for audio streams (1-Channel)
-   return (isEqualNoCase(lhs.mName, rhs.mName) && lhs.mRate == rhs.mRate && 
+	return (lhs.mPayloadType >= 0 && lhs.mPayloadType < 96 && lhs.mPayloadType == rhs.mPayloadType) ||
+			(isEqualNoCase(lhs.mName, rhs.mName) && lhs.mRate == rhs.mRate && 
            (lhs.mEncodingParameters == rhs.mEncodingParameters ||
             (lhs.mEncodingParameters.empty() && rhs.mEncodingParameters == defaultEncodingParameters) ||
             (lhs.mEncodingParameters == defaultEncodingParameters && rhs.mEncodingParameters.empty())));

--- a/resip/stack/SetTransactionMessageFilter.hxx
+++ b/resip/stack/SetTransactionMessageFilter.hxx
@@ -1,0 +1,50 @@
+#ifndef SetTransactionMessageFilter_Include_Guard
+#define SetTransactionMessageFilter_Include_Guard
+
+#include "resip/stack/TransactionMessage.hxx"
+
+#include "rutil/Data.hxx"
+#include "rutil/resipfaststreams.hxx"
+
+namespace resip
+{
+
+class SipMessage;
+class TransactionController;
+class TransactionState;
+
+class SetTransactionMessageFilter: public TransactionMessage
+{
+   public:
+      SetTransactionMessageFilter(const Data& tid) :
+         mTid(tid)
+      {}
+      virtual ~SetTransactionMessageFilter() {}
+
+/////////////////// Must implement unless abstract ///
+
+      virtual const Data& getTransactionId() const {return mTid;}
+      virtual bool isClientTransaction() const {return false;}
+      virtual EncodeStream& encode(EncodeStream& strm) const
+      {
+         return strm << "SetTransactionMessageFilter: " << mTid;
+      }
+      virtual EncodeStream& encodeBrief(EncodeStream& strm) const
+      {
+         return strm << "SetTransactionMessageFilter: " << mTid;
+      }
+
+      // must return true to proceed with message
+      virtual bool filterMessage(TransactionController& controller, TransactionState& state, SipMessage* msg) = 0;
+
+/////////////////// May override ///
+
+
+   protected:
+      const resip::Data mTid;
+
+}; // class SetTransactionMessageFilter
+
+} // namespace resip
+
+#endif // include guard

--- a/resip/stack/SilentlyAbandonServerTransaction.hxx
+++ b/resip/stack/SilentlyAbandonServerTransaction.hxx
@@ -1,0 +1,46 @@
+#ifndef SilentlyAbandonServerTransaction_Include_Guard
+#define SilentlyAbandonServerTransaction_Include_Guard
+
+#include "resip/stack/TransactionMessage.hxx"
+
+#include "rutil/Data.hxx"
+#include "rutil/resipfaststreams.hxx"
+
+namespace resip
+{
+class SilentlyAbandonServerTransaction : public TransactionMessage
+{
+   public:
+      SilentlyAbandonServerTransaction(const Data& tid) :
+         mTid(tid)
+      {}
+      virtual ~SilentlyAbandonServerTransaction() {}
+
+/////////////////// Must implement unless abstract ///
+
+      virtual const Data& getTransactionId() const {return mTid;}
+      virtual bool isClientTransaction() const {return false;}
+      virtual EncodeStream& encode(EncodeStream& strm) const
+      {
+         return strm << "SilentlyAbandonServerTransaction: " << mTid;
+      }
+      virtual EncodeStream& encodeBrief(EncodeStream& strm) const
+      {
+         return strm << "SilentlyAbandonServerTransaction: " << mTid;
+      }
+
+/////////////////// May override ///
+
+      virtual Message* clone() const
+      {
+         return new SilentlyAbandonServerTransaction(*this);
+      }
+
+   protected:
+      const resip::Data mTid;
+
+}; // class SilentlyAbandonServerTransaction
+
+} // namespace resip
+
+#endif // include guard

--- a/resip/stack/SipStack.hxx
+++ b/resip/stack/SipStack.hxx
@@ -28,6 +28,7 @@ class Uri;
 class TransactionUser;
 class AsyncProcessHandler;
 class Compression;
+class SetTransactionMessageFilter;
 
 
 /**
@@ -187,6 +188,8 @@ class SipStack
       */
       const Uri& getUri() const;
 
+      void setUri(const Uri& uri) { mUri = uri; }
+
       /** 
           Interface for the TU to send a message.  Makes a copy of the
           SipMessage.  Caller is responsible for deleting the memory and may do
@@ -342,6 +345,21 @@ class SipStack
       void abandonServerTransaction(const Data& tid);
 
       /**
+         Tells the stack that the TU has silently abandoned a server transaction. This
+         is provided to allow better behavior in cases where an exception is 
+         thrown due to garbage in the request, and the code catching the 
+         exception has no way of telling whether the original request is still
+         around. This frees the TU of the obligation to respond to the request.
+         @param tid The transaction identifier for the server transaction.
+         @note This function is distinct from cancelClientInviteTransaction().
+      */
+      void silentlyAbandonServerTransaction(const Data& tid);
+
+      /* NTT */
+      void setTransactionMessageFilter(SetTransactionMessageFilter* filter);
+
+
+      /**
          Tells the stack that the TU wishes to CANCEL an INVITE request. This 
          frees the TU of the obligation to keep state on whether a 1xx has come 
          in yet before actually sending a CANCEL request, and also the 
@@ -351,6 +369,15 @@ class SipStack
          @param tid The transaction identifier of the INVITE request sent.
       */
       void cancelClientInviteTransaction(const Data& tid);
+
+      /**
+         Tells the stack that the TU wishes to CANCEL an non-INVITE request. This 
+         frees the TU of the obligation to keep state on whether a 2xx has come 
+         in yet
+         @param tid The transaction identifier of the non-INVITE request sent.
+      */
+      void cancelClientNonInviteTransaction(const Data& tid);
+
 
       /**
           Return true if the stack has new messages for the TU.  Since the addition 
@@ -522,6 +549,9 @@ class SipStack
       Compression &getCompression() { return *mCompression; }
       
       bool isFlowAlive(const resip::Tuple& flow) const;
+
+	  DnsResult* createDnsResult(DnsHandler* handler);
+
       
    private:
       /// Notify an async process handler - if one has been registered

--- a/resip/stack/TcpConnection.cxx
+++ b/resip/stack/TcpConnection.cxx
@@ -80,7 +80,7 @@ TcpConnection::read( char* buf, int count )
 int 
 TcpConnection::write( const char* buf, const int count )
 {
-   DebugLog (<< "Writing " << buf);
+   //DebugLog (<< "Writing " << buf);
 
    assert(buf);
    assert(count > 0);

--- a/resip/stack/TimerMessage.cxx
+++ b/resip/stack/TimerMessage.cxx
@@ -7,9 +7,10 @@
 
 using namespace resip;
 
-TimerMessage::TimerMessage(Data transactionId, Timer::Type type, unsigned long duration)
+TimerMessage::TimerMessage(Data transactionId, Timer::Type type, unsigned long duration, Timer::Id id)
    : mTransactionId(transactionId),
      mType(type),
+     mId(id),
      mDuration(duration) {}
 
 const Data&
@@ -22,6 +23,12 @@ Timer::Type
 TimerMessage::getType() const
 {
    return mType;
+}
+
+Timer::Id
+TimerMessage::getId() const
+{
+   return mId;
 }
 
 unsigned long

--- a/resip/stack/TimerMessage.hxx
+++ b/resip/stack/TimerMessage.hxx
@@ -14,11 +14,12 @@ class TimerMessage : public TransactionMessage
 {
    public:
       RESIP_HeapCount(TimerMessage);
-      TimerMessage(Data transactionId, Timer::Type type, unsigned long duration);
+      TimerMessage(Data transactionId, Timer::Type type, unsigned long duration, Timer::Id id);
       ~TimerMessage();
 
       virtual const Data& getTransactionId() const;
       Timer::Type getType() const;
+      Timer::Id getId() const;
       unsigned long getDuration() const;
       bool isClientTransaction() const;
       
@@ -28,6 +29,7 @@ class TimerMessage : public TransactionMessage
    private:
       Data mTransactionId;
       Timer::Type mType;
+      Timer::Id mId;
       unsigned long mDuration;
 };
 

--- a/resip/stack/TimerQueue.cxx
+++ b/resip/stack/TimerQueue.cxx
@@ -155,7 +155,7 @@ TimerQueue::process()
       std::multiset<Timer>::iterator end = mTimers.upper_bound(now);
       for (std::multiset<Timer>::iterator i = mTimers.begin(); i != end; ++i)
       {
-         mFifo.add(new TimerMessage(i->mTransactionId, i->mType, i->mDuration));
+          mFifo.add(new TimerMessage(i->mTransactionId, i->mType, i->mDuration, i->getId()));
       }
       mTimers.erase(mTimers.begin(), end);
    }

--- a/resip/stack/Token.cxx
+++ b/resip/stack/Token.cxx
@@ -55,6 +55,11 @@ Token::isEqual(const Token& rhs) const
    return (value() == rhs.value());
 }
 
+bool Token::isEqualNoCase(const Token& rhs) const
+{
+	return ::isEqualNoCase(value(), rhs.value());
+}
+
 bool
 Token::operator==(const Token& rhs) const
 {

--- a/resip/stack/Token.hxx
+++ b/resip/stack/Token.hxx
@@ -25,6 +25,7 @@ class Token : public ParserCategory
       Token(const Token&);
       Token& operator=(const Token&);
       bool isEqual(const Token& rhs) const;
+	  bool isEqualNoCase(const Token & rhs) const;
       bool operator==(const Token& rhs) const;
       bool operator!=(const Token& rhs) const;
       bool operator<(const Token& rhs) const;

--- a/resip/stack/TransactionController.cxx
+++ b/resip/stack/TransactionController.cxx
@@ -3,8 +3,11 @@
 #endif
 
 #include "resip/stack/AbandonServerTransaction.hxx"
+#include "resip/stack/SilentlyAbandonServerTransaction.hxx"
+#include "resip/stack/SetTransactionMessageFilter.hxx"
 #include "resip/stack/ApplicationMessage.hxx"
 #include "resip/stack/CancelClientInviteTransaction.hxx"
+#include "resip/stack/CancelClientNonInviteTransaction.hxx"
 #include "resip/stack/ShutdownMessage.hxx"
 #include "resip/stack/SipMessage.hxx"
 #include "resip/stack/TransactionController.hxx"
@@ -174,11 +177,29 @@ TransactionController::abandonServerTransaction(const Data& tid)
 }
 
 void 
+TransactionController::silentlyAbandonServerTransaction(const Data& tid)
+{
+   mStateMacFifo.add(new SilentlyAbandonServerTransaction(tid));
+}
+
+void 
+TransactionController::setTransactionMessageFilter(SetTransactionMessageFilter* filter)
+{
+    mStateMacFifo.add(filter);
+}
+
+
+void 
 TransactionController::cancelClientInviteTransaction(const Data& tid)
 {
    mStateMacFifo.add(new CancelClientInviteTransaction(tid));
 }
 
+void 
+TransactionController::cancelClientNonInviteTransaction(const Data& tid)
+{
+   mStateMacFifo.add(new CancelClientNonInviteTransaction(tid));
+}
 
 /* ====================================================================
  * The Vovida Software License, Version 1.0 

--- a/resip/stack/TransactionController.hxx
+++ b/resip/stack/TransactionController.hxx
@@ -14,6 +14,7 @@ class ApplicationMessage;
 class StatisticsManager;
 class SipStack;
 class Compression;
+class SetTransactionMessageFilter;
 
 class TransactionController
 {
@@ -67,8 +68,11 @@ class TransactionController
       }
 
       void abandonServerTransaction(const Data& tid);
+      void silentlyAbandonServerTransaction(const Data& tid);
+      void setTransactionMessageFilter(SetTransactionMessageFilter* filter);
 
       void cancelClientInviteTransaction(const Data& tid);
+      void cancelClientNonInviteTransaction(const Data& tid);
 
    private:
       TransactionController(const TransactionController& rhs);

--- a/resip/stack/TransactionState.hxx
+++ b/resip/stack/TransactionState.hxx
@@ -3,6 +3,7 @@
 
 #include <iosfwd>
 #include <memory>
+#include "rutil/Timer.hxx"
 #include "rutil/dns/DnsHandler.hxx"
 #include "resip/stack/Transport.hxx"
 #include "rutil/HeapInstanceCounter.hxx"
@@ -18,6 +19,7 @@ class TransactionController;
 class TransactionUser;
 class NameAddr;
 class Via;
+class SetTransactionMessageFilter;
 
 class TransactionState : public DnsHandler
 {
@@ -86,7 +88,10 @@ class TransactionState : public DnsHandler
       bool isReliabilityIndication(TransactionMessage* msg) const;
       bool isSentIndication(TransactionMessage* msg) const;
       bool isAbandonServerTransaction(TransactionMessage* msg) const;
-      bool isCancelClientTransaction(TransactionMessage* msg) const;
+      bool isSilentlyAbandonServerTransaction(TransactionMessage* msg) const;
+      static bool isSetTransactionMessageFilter(TransactionMessage* msg);
+      static bool isCancelClientTransaction(TransactionMessage* msg);
+      static bool isCancelClientNonInviteTransaction(TransactionMessage* msg);
       void sendToTU(TransactionMessage* msg) const;
       static void sendToTU(TransactionUser* tu, TransactionController& controller, TransactionMessage* msg);
       void sendToWire(TransactionMessage* msg, bool retransmit=false);
@@ -110,7 +115,10 @@ class TransactionState : public DnsHandler
 
       void saveOriginalContactAndVia(const SipMessage& msg);
       void restoreOriginalContactAndVia();
-      
+
+      SetTransactionMessageFilter* mFilter;
+      Timer::Id mTryingTimerId;
+
       TransactionController& mController;
       
       Machine mMachine;

--- a/resip/stack/Transport.hxx
+++ b/resip/stack/Transport.hxx
@@ -16,6 +16,10 @@ class SipMessage;
 class Connection;
 class Compression;
 
+
+void LogOutboundMessage(const SipMessage &msg, const Tuple &transport);
+void LogInboundMessage(const char *buf, int length, const Tuple &transport);
+	
 class Transport
 {
    public:

--- a/resip/stack/UdpTransport.cxx
+++ b/resip/stack/UdpTransport.cxx
@@ -323,8 +323,10 @@ UdpTransport::process(FdSet& fdset)
       //DebugLog ( << "UDP Rcv : " << len << " b" );
       //DebugLog ( << Data(buffer, len).escaped().c_str());
 
-      SipMessage* message = new SipMessage(this);
-
+	   LogInboundMessage(buffer, len, tuple);
+	   
+	   SipMessage* message = new SipMessage(this, len);
+	   
       // set the received from information into the received= parameter in the
       // via
 

--- a/resip/stack/Uri.cxx
+++ b/resip/stack/Uri.cxx
@@ -768,12 +768,18 @@ Uri::parse(ParseBuffer& pb)
    {
       pb.reset(start);
       start = pb.position();
-      pb.skipToOneOf(":@");
+      pb.skipToOneOf(":@;");
 #ifdef HANDLE_CHARACTER_ESCAPING
       pb.dataUnescaped(mUser, start);
 #else
       pb.data(mUser, start);
 #endif
+      if (!pb.eof() && *pb.position() == Symbols::SEMI_COLON[0])
+      {
+         const char* anchor = pb.skipChar();
+         pb.skipToOneOf(":@");
+         pb.data(mUserParameters, anchor);
+      }
       if (!pb.eof() && *pb.position() == Symbols::COLON[0])
       {
          start = pb.skipChar();

--- a/resip/stack/Via.cxx
+++ b/resip/stack/Via.cxx
@@ -13,6 +13,7 @@ using namespace std;
 
 #define RESIPROCATE_SUBSYSTEM Subsystem::SIP
 
+bool Via::mInsertRPort = true;
 
 //====================
 // Via:
@@ -27,7 +28,10 @@ Via::Via()
 {
    // insert a branch in all Vias (default constructor)
    this->param(p_branch);
-   this->param(p_rport); // add the rport parameter by default as per rfc 3581
+   if (mInsertRPort)
+   {
+      this->param(p_rport); // add the rport parameter by default as per rfc 3581
+   }
 }
 
 Via::Via(HeaderFieldValue* hfv, Headers::Type type) 
@@ -47,6 +51,11 @@ Via::Via(const Via& rhs)
      mSentHost(rhs.mSentHost),
      mSentPort(rhs.mSentPort)
 {
+}
+
+void Via::setInsertRPort(bool use)
+{
+    mInsertRPort = use;
 }
 
 Via&
@@ -227,6 +236,7 @@ Via::encodeParsed(EncodeStream& str) const
    encodeParameters(str);
    return str;
 }
+
 
 /* ====================================================================
  * The Vovida Software License, Version 1.0 

--- a/resip/stack/Via.hxx
+++ b/resip/stack/Via.hxx
@@ -33,6 +33,7 @@ class Via : public ParserCategory
       const Data& sentHost() const;
       int& sentPort();
       int sentPort() const;
+      static void setInsertRPort(bool use);
 
       virtual void parse(ParseBuffer& pb);
       virtual ParserCategory* clone() const;
@@ -44,6 +45,7 @@ class Via : public ParserCategory
       mutable Data mTransport;
       mutable Data mSentHost;
       mutable int mSentPort;
+      static  bool mInsertRPort;
 };
 typedef ParserContainer<Via> Vias;
 

--- a/resip/stack/XMLCursor.cxx
+++ b/resip/stack/XMLCursor.cxx
@@ -93,7 +93,7 @@ XMLCursor::XMLCursor(const ParseBuffer& pb)
    }
    else
    {
-      mRoot = new Node(ParseBuffer(start, pb.end() - start));
+      mRoot = new Node(ParseBuffer(start, static_cast<unsigned int>(pb.end() - start)));
    }
    mCursor = mRoot;
 
@@ -195,7 +195,7 @@ XMLCursor::parseNextRootChild()
    if (*mRoot->mPb.position() == Symbols::LA_QUOTE[0])
    {
       ParseBuffer pb(mRoot->mPb.position(), 
-                     mRoot->mPb.end() - mRoot->mPb.position());
+                    static_cast<unsigned int>(mRoot->mPb.end() - mRoot->mPb.position()));
       pb.skipChar();
       if (!pb.eof() && *pb.position() == Symbols::SLASH[0])
       {
@@ -223,7 +223,7 @@ XMLCursor::parseNextRootChild()
    {
       const char* anchor = mRoot->mPb.position();
       mRoot->mPb.skipToChar(Symbols::LA_QUOTE[0]);
-      Node* leaf = new Node(ParseBuffer(anchor, mRoot->mPb.position() - anchor));
+      Node* leaf = new Node(ParseBuffer(anchor, static_cast<unsigned int>(mRoot->mPb.position() - anchor)));
       leaf->mIsLeaf = true;
       mRoot->addChild(leaf);
    }
@@ -436,7 +436,7 @@ XMLCursor::encode(EncodeStream& str, const AttributeMap& attrs)
 }
 
 XMLCursor::Node::Node(const ParseBuffer& pb)
-   : mPb(pb.position(), pb.end() - pb.position()),
+   : mPb(pb.position(), static_cast<unsigned int>(pb.end() - pb.position())),
      mParent(0),
      mChildren(),
      mNext(mChildren.begin()),
@@ -504,7 +504,7 @@ XMLCursor::Node::skipToEndTag()
    if (*(mPb.position()-1) == Symbols::SLASH[0])
    {
       mPb.skipChar();
-      mPb = ParseBuffer(mPb.start(), mPb.position() - mPb.start());
+      mPb = ParseBuffer(mPb.start(), static_cast<unsigned int>(mPb.position() - mPb.start()));
       return;
    }
 
@@ -526,7 +526,7 @@ XMLCursor::Node::skipToEndTag()
       {
          const char* anchor = mPb.position();
          mPb.skipToChar(Symbols::LA_QUOTE[0]);
-         Node* leaf = new Node(ParseBuffer(anchor, mPb.position() - anchor));
+         Node* leaf = new Node(ParseBuffer(anchor, static_cast<unsigned int>(mPb.position() - anchor)));
          leaf->mIsLeaf = true;
          addChild(leaf);
       }
@@ -556,7 +556,7 @@ XMLCursor::Node::skipToEndTag()
          {
             mPb.skipToChar(Symbols::RA_QUOTE[0]);
             mPb.skipChar();
-            mPb = ParseBuffer(mPb.start(), mPb.position() - mPb.start());
+            mPb = ParseBuffer(mPb.start(), static_cast<unsigned int>(mPb.position() - mPb.start()));
             return;
          }
          else
@@ -610,7 +610,7 @@ XMLCursor::Node::skipComments(ParseBuffer& pb)
 EncodeStream&
 resip::operator<<(EncodeStream& str, const XMLCursor::Node& node)
 {
-   Data::size_type size = node.mPb.end() - node.mPb.start();
+   Data::size_type size = static_cast<Data::size_type>(node.mPb.end() - node.mPb.start());
 
    static const Data::size_type showSize(35);
 

--- a/resip/stack/ssl/DtlsTransport.cxx
+++ b/resip/stack/ssl/DtlsTransport.cxx
@@ -333,6 +333,8 @@ DtlsTransport::_read( FdSet& fdset )
    message->setSource( tuple ) ;
    //DebugLog (<< "Received from: " << tuple);
    
+	LogInboundMessage((char *)pt, len , tuple);
+	
    // Tell the SipMessage about this datagram buffer.
    message->addBuffer( (char *)pt ) ;
    

--- a/resip/stack/ssl/TlsConnection.cxx
+++ b/resip/stack/ssl/TlsConnection.cxx
@@ -48,7 +48,8 @@ TlsConnection::TlsConnection( Transport* transport, const Tuple& tuple,
       DebugLog( << "Trying to form TLS connection - acting as server" );
       if ( mDomain.empty() )
       {
-         ErrLog(<< "Tranport was not created with a server domain so can not act as server" ); 
+		//alexkr: submit change to community
+         ErrLog(<< "Transport was not created with a server domain so can not act as server" ); 
          throw Security::Exception("Trying to act as server but no domain specified",
                                    __FILE__,__LINE__);
       }
@@ -619,7 +620,7 @@ TlsConnection::computePeerName()
    }
 
    // print session infor       
-   SSL_CIPHER *ciph;
+   const SSL_CIPHER *ciph;
    ciph=SSL_get_current_cipher(mSsl);
    InfoLog( << "TLS sessions set up with " 
             <<  SSL_get_version(mSsl) << " "

--- a/rutil/Data.cxx
+++ b/rutil/Data.cxx
@@ -191,57 +191,57 @@ Data::init(DataLocalSize<RESIP_DATA_LOCAL_SIZE> arg)
 }
 
 Data::Data() 
-   : mSize(0),
-     mBuf(mPreBuffer),
-     mCapacity(LocalAlloc),
-     mMine(Borrow)
+   :mBuf(mPreBuffer),
+    mSize(0),
+    mCapacity(LocalAlloc),
+    mMine(Borrow)
 {
    mBuf[mSize] = 0;
 }
 
 Data::Data(int capacity,
            const Data::PreallocateType&) 
-   : mSize(0),
-     mBuf(capacity > LocalAlloc 
-          ? new char[capacity + 1]
-          : mPreBuffer),
-     mCapacity(capacity > LocalAlloc
-               ? capacity
-               : LocalAlloc),
-     mMine(capacity > LocalAlloc ? Take : Borrow)
 {
-   assert( capacity >= 0 );
-   mBuf[mSize] = 0;
+    mSize = 0;
+    mCapacity = (capacity > LocalAlloc
+        ? capacity
+        : LocalAlloc);
+    mBuf = (capacity > LocalAlloc
+        ? new char[capacity + 1]
+        : mPreBuffer);
+    mMine = (capacity > LocalAlloc ? Take : Borrow);
+        assert( capacity >= 0 );
+    mBuf[mSize] = 0;
 }
 
 #ifdef DEPRECATED_PREALLOC
 // pre-allocate capacity
 Data::Data(int capacity, bool) 
-   : mSize(0),
-     mBuf(capacity > LocalAlloc 
-          ? new char[capacity + 1]
-          : mPreBuffer),
-     mCapacity(capacity > LocalAlloc
-               ? capacity
-               : LocalAlloc),
-     mMine(capacity > LocalAlloc ? Take : Borrow)
 {
-   assert( capacity >= 0 );
+    mSize = 0;
+    mCapacity = (capacity > LocalAlloc
+        ? capacity
+        : LocalAlloc);
+    mBuf = (capacity > LocalAlloc
+        ? new char[capacity + 1]
+        : mPreBuffer);
+    mMine = (capacity > LocalAlloc ? Take : Borrow);
+    assert( capacity >= 0 );
    mBuf[mSize] = 0;
 }
 #endif
 
-Data::Data(const char* str, int length) 
-   : mSize(length),
-     mBuf(mSize > LocalAlloc 
-          ? new char[mSize + 1]
-          : mPreBuffer),
-     mCapacity(mSize > LocalAlloc
-               ? mSize
-               : LocalAlloc),
-     mMine(mSize > LocalAlloc ? Take : Borrow)
+Data::Data(const char* str, Data::size_type length) 
 {
-   if (mSize > 0)
+    mSize = length;
+    mCapacity = (mSize > LocalAlloc
+        ? mSize
+        : LocalAlloc);
+    mBuf = (mSize > LocalAlloc
+        ? new char[mSize + 1]
+        : mPreBuffer);
+    mMine = (mSize > LocalAlloc ? Take : Borrow);
+    if (mSize > 0)
    {
       assert(str);
       memcpy(mBuf, str, mSize);
@@ -249,17 +249,17 @@ Data::Data(const char* str, int length)
    mBuf[mSize]=0;
 }
 
-Data::Data(const unsigned char* str, int length) 
-   : mSize(length),
-     mBuf(mSize > LocalAlloc 
-          ? new char[mSize + 1]
-          : mPreBuffer),
-     mCapacity(mSize > LocalAlloc
-               ? mSize
-               : LocalAlloc),
-     mMine(mSize > LocalAlloc ? Take : Borrow)
+Data::Data(const unsigned char* str, Data::size_type length) 
 {
-   if (mSize > 0)
+    mSize = length;
+    mCapacity = (mSize > LocalAlloc
+        ? mSize
+        : LocalAlloc);
+    mBuf = (mSize > LocalAlloc
+        ? new char[mSize + 1]
+        : mPreBuffer);
+    mMine = (mSize > LocalAlloc ? Take : Borrow);
+    if (mSize > 0)
    {
       assert(str);
       memcpy(mBuf, str, mSize);
@@ -270,40 +270,40 @@ Data::Data(const unsigned char* str, int length)
 // share memory KNOWN to be in a surrounding scope
 // wears off on, c_str, operator=, operator+=, non-const
 // operator[], append, reserve
-Data::Data(const char* str, int length, bool) 
-   : mSize(length),
-     mBuf(const_cast<char*>(str)),
-     mCapacity(mSize),
-     mMine(Share)
+Data::Data(const char* str, Data::size_type length, bool) 
 {
-   assert(str);
+    mSize = length;
+    mCapacity = mSize;
+    mBuf = const_cast<char*>(str);
+    mMine = Share;
+    assert(str);
 }
 
-Data::Data(ShareEnum se, const char* buffer, int length)
-   : mSize(length),
-     mBuf(const_cast<char*>(buffer)),
-     mCapacity(mSize),
-     mMine(se)
+Data::Data(ShareEnum se, const char* buffer, Data::size_type length)
 {
-   assert(buffer);
+    mSize = length;
+    mCapacity = mSize;
+    mBuf = const_cast<char*>(buffer);
+    mMine = se;
+    assert(buffer);
 }
 
 Data::Data(ShareEnum se, const char* buffer)
-   : mSize(strlen(buffer)),
-     mBuf(const_cast<char*>(buffer)),
-     mCapacity(mSize),
-     mMine(se)
 {
-   assert(buffer);
+    mSize = static_cast<Data::size_type>(strlen(buffer));
+    mCapacity = mSize;
+    mBuf = const_cast<char*>(buffer);
+    mMine = se;
+    assert(buffer);
 }
 
 Data::Data(ShareEnum se, const Data& staticData)
-   : mSize(staticData.mSize),
-     mBuf(staticData.mBuf),
-     mCapacity(mSize),
-     mMine(Share)
 {
-   // !dlb! maybe:
+    mSize = staticData.mSize;
+    mCapacity = mSize;
+    mBuf = staticData.mBuf;
+    mMine = Share;
+  // !dlb! maybe:
    // if you are trying to use Take, but make sure that you unset the mMine on
    // the staticData
    assert(se == Share); // makes no sense to call this with 'Take'.
@@ -311,16 +311,16 @@ Data::Data(ShareEnum se, const Data& staticData)
 //=============================================================================
 
 Data::Data(const char* str) 
-   : mSize(str ? strlen(str) : 0),
-     mBuf(mSize > LocalAlloc
-          ? new char[mSize + 1]
-          : mPreBuffer),
-     mCapacity(mSize > LocalAlloc
-               ? mSize
-               : LocalAlloc),
-     mMine(mSize > LocalAlloc ? Take : Borrow)
 {
-   if (str)
+    mSize = static_cast<Data::size_type>(str ? strlen(str) : 0);
+    mCapacity = (mSize > LocalAlloc
+        ? mSize
+        : LocalAlloc);
+    mBuf = (mSize > LocalAlloc
+        ? new char[mSize + 1]
+        : mPreBuffer);
+    mMine = (mSize > LocalAlloc ? Take : Borrow);
+    if (str)
    {
       memcpy(mBuf, str, mSize+1);
    }
@@ -331,29 +331,29 @@ Data::Data(const char* str)
 }
 
 Data::Data(const string& str)
-   : mSize(str.size()),
-     mBuf(mSize > LocalAlloc
-          ? new char[mSize + 1]
-          : mPreBuffer),
-     mCapacity(mSize > LocalAlloc
-               ? mSize
-               : LocalAlloc),
-     mMine(mSize > LocalAlloc ? Take : Borrow)
 {
-   memcpy(mBuf, str.c_str(), mSize + 1);
+    mSize = static_cast<Data::size_type>(str.size());
+    mCapacity = (mSize > LocalAlloc
+        ? mSize
+        : LocalAlloc);
+    mBuf = (mSize > LocalAlloc
+        ? new char[mSize + 1]
+        : mPreBuffer);
+    mMine = (mSize > LocalAlloc ? Take : Borrow);
+    memcpy(mBuf, str.c_str(), mSize + 1);
 }
 
 Data::Data(const Data& data) 
-   : mSize(data.mSize),
-     mBuf(mSize > LocalAlloc
-          ? new char[mSize + 1]
-          : mPreBuffer),
-     mCapacity(mSize > LocalAlloc
-               ? mSize
-               : LocalAlloc),
-     mMine(mSize > LocalAlloc ? Take : Borrow)
 {
-   if (mSize)
+    mSize = data.mSize;
+    mCapacity = (mSize > LocalAlloc
+        ? mSize
+        : LocalAlloc);
+    mBuf = (mSize > LocalAlloc
+        ? new char[mSize + 1]
+        : mPreBuffer);
+    mMine = (mSize > LocalAlloc ? Take : Borrow);
+    if (mSize)
    {
       memcpy(mBuf, data.mBuf, mSize);
    }
@@ -372,16 +372,16 @@ Data::Data(Data &&data)
 static const int IntMaxSize = 12;
 
 Data::Data(int val)
-   : mSize(0),
-     mBuf(IntMaxSize > LocalAlloc 
-          ? new char[IntMaxSize + 1]
-          : mPreBuffer),
-     mCapacity(IntMaxSize > LocalAlloc
-               ? IntMaxSize
-               : LocalAlloc),
-     mMine(IntMaxSize > LocalAlloc ? Take : Borrow)
 {
-   if (val == 0)
+    mSize = 0;
+    mCapacity = (IntMaxSize > LocalAlloc
+        ? IntMaxSize
+        : LocalAlloc);
+    mBuf = (IntMaxSize > LocalAlloc
+        ? new char[IntMaxSize + 1]
+        : mPreBuffer);
+    mMine = (IntMaxSize > LocalAlloc ? Take : Borrow);
+    if (val == 0)
    {
       mBuf[0] = '0';
       mBuf[1] = 0;
@@ -428,16 +428,16 @@ Data::Data(int val)
 
 static const int MaxLongSize = (sizeof(unsigned long)/sizeof(int))*IntMaxSize;
 Data::Data(unsigned long value)
-   : mSize(0),
-     mBuf(MaxLongSize > LocalAlloc 
-          ? new char[MaxLongSize + 1]
-          : mPreBuffer),
-     mCapacity(MaxLongSize > LocalAlloc
-               ? MaxLongSize
-               : LocalAlloc),
-     mMine(MaxLongSize > LocalAlloc ? Take : Borrow)
 {
-   if (value == 0)
+    mSize = 0;
+    mCapacity = (MaxLongSize > LocalAlloc
+        ? MaxLongSize
+        : LocalAlloc);
+    mBuf = (MaxLongSize > LocalAlloc
+        ? new char[MaxLongSize + 1]
+        : mPreBuffer);
+    mMine = (MaxLongSize > LocalAlloc ? Take : Borrow);
+    if (value == 0)
    {
       mBuf[0] = '0';
       mBuf[1] = 0;
@@ -469,16 +469,16 @@ Data::Data(unsigned long value)
 static const int DoubleMaxSize = MaxLongSize + Data::MaxDigitPrecision;
 Data::Data(double value, 
            Data::DoubleDigitPrecision precision)
-   : mSize(0),
-     mBuf(DoubleMaxSize + precision > LocalAlloc 
-          ? new char[DoubleMaxSize + precision + 1]
-          : mPreBuffer),
-     mCapacity(DoubleMaxSize + precision > LocalAlloc
-               ? DoubleMaxSize + precision
-               : LocalAlloc),
-     mMine(DoubleMaxSize + precision > LocalAlloc ? Take : Borrow)
 {
-   assert(precision >= 0);
+    mSize = 0;
+    mCapacity = (DoubleMaxSize + precision > LocalAlloc
+        ? DoubleMaxSize + precision
+        : LocalAlloc);
+    mBuf = (DoubleMaxSize + precision > LocalAlloc
+        ? new char[DoubleMaxSize + precision + 1]
+        : mPreBuffer);
+    mMine = (DoubleMaxSize + precision > LocalAlloc ? Take : Borrow);
+    assert(precision >= 0);
    assert(precision < MaxDigitPrecision);
 
    double v = value;
@@ -555,16 +555,16 @@ Data::Data(double value,
 #endif
 
 Data::Data(unsigned int value)
-   : mSize(0),
-     mBuf(IntMaxSize > LocalAlloc 
-          ? new char[IntMaxSize + 1]
-          : mPreBuffer),
-     mCapacity(IntMaxSize > LocalAlloc
-               ? IntMaxSize
-               : LocalAlloc),
-     mMine(IntMaxSize > LocalAlloc ? Take : Borrow)
 {
-   if (value == 0)
+    mSize = 0;
+    mCapacity = (IntMaxSize > LocalAlloc
+        ? IntMaxSize
+        : LocalAlloc);
+    mBuf = (IntMaxSize > LocalAlloc
+        ? new char[IntMaxSize + 1]
+        : mPreBuffer);
+    mMine = (IntMaxSize > LocalAlloc ? Take : Borrow);
+    if (value == 0)
    {
       mBuf[0] = '0';
       mBuf[1] = 0;
@@ -596,16 +596,16 @@ Data::Data(unsigned int value)
 static const int UInt64MaxSize = 20;
 
 Data::Data(UInt64 value)
-   : mSize(0),
-     mBuf(UInt64MaxSize > LocalAlloc 
-          ? new char[UInt64MaxSize + 1]
-          : mPreBuffer),
-     mCapacity(UInt64MaxSize > LocalAlloc
-               ? UInt64MaxSize
-               : LocalAlloc),
-     mMine(UInt64MaxSize > LocalAlloc ? Take : Borrow)
 {
-   if (value == 0)
+    mSize = 0;
+    mCapacity = (UInt64MaxSize > LocalAlloc
+        ? UInt64MaxSize
+        : LocalAlloc);
+    mBuf = (UInt64MaxSize > LocalAlloc
+        ? new char[UInt64MaxSize + 1]
+        : mPreBuffer);
+    mMine = (UInt64MaxSize > LocalAlloc ? Take : Borrow);
+    if (value == 0)
    {
       mBuf[0] = '0';
       mBuf[1] = 0;
@@ -635,24 +635,24 @@ Data::Data(UInt64 value)
 
 static const int CharMaxSize = 1;
 Data::Data(char c)
-   : mSize(1),
-     mBuf(CharMaxSize > LocalAlloc 
-          ? new char[CharMaxSize + 1]
-          : mPreBuffer),
-     mCapacity(CharMaxSize > LocalAlloc
-               ? CharMaxSize
-               : LocalAlloc),
-     mMine(CharMaxSize > LocalAlloc ? Take : Borrow)
 {
+    mSize = 1;
+    mCapacity = (CharMaxSize > LocalAlloc
+        ? CharMaxSize
+        : LocalAlloc);
+    mBuf = (CharMaxSize > LocalAlloc
+        ? new char[CharMaxSize + 1]
+        : mPreBuffer);
+    mMine = (CharMaxSize > LocalAlloc ? Take : Borrow);
    mBuf[0] = c;
    mBuf[1] = 0;
 }
 
 Data::Data(bool value)
-   : mSize(value ? 4 : 5), 
-     mBuf(value ? const_cast<char*>("true") : const_cast<char*>("false")),
-     mCapacity(value ? 4 : 5),
-     mMine(Borrow)
+   :mBuf(value ? const_cast<char*>("true") : const_cast<char*>("false")),
+    mSize(value ? 4 : 5), 
+    mCapacity(value ? 4 : 5),
+    mMine(Borrow)
 {}
 
 Data::~Data()
@@ -711,7 +711,7 @@ bool
 resip::operator<(const Data& lhs, const char* rhs)
 {
    assert(rhs);
-   Data::size_type l = strlen(rhs);
+   Data::size_type l = static_cast<Data::size_type>(strlen(rhs));
    int res = memcmp(lhs.mBuf, rhs, resipMin(lhs.mSize, l));
 
    if (res < 0)
@@ -732,7 +732,7 @@ bool
 resip::operator<(const char* lhs, const Data& rhs)
 {
    assert(lhs);
-   Data::size_type l = strlen(lhs);
+   Data::size_type l = static_cast<Data::size_type>(strlen(lhs));
    int res = memcmp(lhs, rhs.mBuf, resipMin(l, rhs.mSize));
 
    if (res < 0)
@@ -838,7 +838,7 @@ Data&
 Data::operator+=(const char* str)
 {
    assert(str);
-   return append(str, strlen(str));
+   return append(str, static_cast<Data::size_type>(strlen(str)));
 }
 
 Data&
@@ -910,7 +910,7 @@ Data&
 Data::operator=(const char* str)
 {
    assert(str);
-   size_type l = strlen(str);
+   size_type l = static_cast<Data::size_type>(strlen(str));
 
    if (mMine == Share)
    {
@@ -935,7 +935,7 @@ Data
 Data::operator+(const char* str) const
 {
    assert(str);
-   size_t l = strlen(str);
+   Data::size_type l = static_cast<Data::size_type>(strlen(str));
    Data tmp(mSize + l, Data::Preallocate);
    tmp.mSize = mSize + l;
    tmp.mCapacity = tmp.mSize;
@@ -1184,8 +1184,8 @@ Data::charUnencoded() const
                return ret;
             }
             
-            int highInt = high - hexmap;
-            int lowInt = low - hexmap;
+            int highInt = static_cast<int>(high - hexmap);
+            int lowInt = static_cast<int>(low - hexmap);
             ret += char(highInt<<4 | lowInt);
             i += 2;
          }
@@ -1436,7 +1436,7 @@ Data::xmlCharDataDecode(EncodeStream& s) const
 }
 
 Data
-Data::trunc(size_t s) const
+Data::trunc(size_type s) const
 {
    if (size() <= s)
    {
@@ -1494,6 +1494,25 @@ Data::uppercase()
       ++p;
    }
    return *this;
+}
+
+void Data::trimTrailingWhitespace()
+{
+    if (mSize <= 0)
+        return;
+	
+    for (; mSize > 0; mSize--)
+    {       
+        switch (*(mBuf + mSize - 1)) {
+            case ' ':
+            case '\t':
+            case '\n':
+            case '\r':
+                continue;
+            default:
+                return;
+        }
+    }
 }
 
 Data&
@@ -1754,7 +1773,7 @@ Data::find(const Data& match,
       pb.skipToChars(match);
       if (!pb.eof())
       {
-         return pb.position() - pb.start() + start;
+         return static_cast<Data::size_type>(pb.position() - pb.start()) + start;
       }
    }
 
@@ -1829,15 +1848,15 @@ static const unsigned char randomPermutation[256] =
    235, 217, 165, 122, 15, 141, 158, 147, 240, 24, 162, 18, 60, 73, 227, 248
 };
 
-size_t
-Data::rawHash(const unsigned char* c, size_t size)
+UInt32
+Data::rawHash(const unsigned char* c, size_type size)
 {
    // 4 byte Pearson's hash
    // essentially random hashing
 
    union 
    {
-         size_t st;
+         UInt32 st;
          unsigned char bytes[4];
    };
    st = 0; // suppresses warnings about unused st
@@ -1860,13 +1879,13 @@ Data::rawHash(const unsigned char* c, size_t size)
 }
 
 // use only for ascii characters!
-size_t 
-Data::rawCaseInsensitiveHash(const unsigned char* c, size_t size)
+UInt32 
+Data::rawCaseInsensitiveHash(const unsigned char* c, size_type size)
 {
 
    union 
    {
-         size_t st;
+         UInt32 st;
          unsigned char bytes[4];
    };
    st = 0; // suppresses warnings about unused st
@@ -1889,6 +1908,7 @@ Data::rawCaseInsensitiveHash(const unsigned char* c, size_t size)
    return ntohl(st);
 }
 
+/*
 Data
 bits(size_t v)
 {
@@ -1901,14 +1921,15 @@ bits(size_t v)
 
    return ret;
 }
+*/
 
-size_t
+UInt32
 Data::hash() const
 {
    return rawHash((const unsigned char*)(this->data()), this->size());
 }
 
-size_t
+UInt32
 Data::caseInsensitivehash() const
 {
    return rawCaseInsensitiveHash((const unsigned char*)(this->data()), this->size());
@@ -2073,6 +2094,26 @@ Data::base64encode(bool useSafeSet) const
 
    return Data(Data::Take, reinterpret_cast<char*>(dstData),
                dstIndex);
+}
+
+Data
+Data::stripNonDigits(bool stripPlus) const
+{
+   Data ret(mSize, Data::Preallocate);
+
+   const char* p = mBuf;
+   char* r = ret.mBuf;
+   for (size_type i=0; i < mSize; ++i)
+   {
+	   if ((*p>='0' && *p<='9') || *p=='#' || *p=='*')
+		  *r++ = *p;
+	  else if (!stripPlus && *p=='+')
+		  *r++ = *p;
+	  p++;
+   }
+   *r = 0;
+   ret.mSize = static_cast<Data::size_type>(r - ret.mBuf);
+   return ret;
 }
 
 

--- a/rutil/Data.hxx
+++ b/rutil/Data.hxx
@@ -10,7 +10,7 @@
 #include "rutil/HashMap.hxx"
 
 #ifndef RESIP_DATA_LOCAL_SIZE
-#define RESIP_DATA_LOCAL_SIZE 16
+#define RESIP_DATA_LOCAL_SIZE 30
 #endif
 
 class TestData;
@@ -543,6 +543,12 @@ class Data
       */
       Data trunc(size_type trunc) const;
 
+	
+	/**
+	 self-explanatory.
+	 */
+	void trimTrailingWhitespace();
+	
       /**
         Clears the contents of this Data. This call does not modify
         the capacity of the Data.
@@ -623,6 +629,8 @@ class Data
           target. Returns the number of matches.
       */
       int replace(const Data& match, const Data& target);
+      
+	  Data stripNonDigits(bool stripPlus=true) const;
       
       /**
         Constant that represents a zero-length data.
@@ -725,12 +733,12 @@ class Data
 	  Larger LocalAlloc makes for larger objects that have Data members but
 	  bulk allocation/deallocation of Data  members. */
       enum {LocalAlloc = RESIP_DATA_LOCAL_SIZE };
-      char mPreBuffer[LocalAlloc+1];
 
-      size_type mSize;
       char* mBuf;
+      size_type mSize;
       size_type mCapacity;
-      ShareEnum mMine;
+      char mPreBuffer[LocalAlloc+1];
+      char mMine;
       // The invariant for a Data with !mMine is mSize == mCapacity
 
       static const bool isCharHex[256];

--- a/rutil/DnsUtil.cxx
+++ b/rutil/DnsUtil.cxx
@@ -56,7 +56,7 @@ DnsUtil::lookupARecords(const Data& host)
    struct hostent hostbuf; 
    char buffer[8192];
    result = gethostbyname_r( host.c_str(), &hostbuf, buffer, sizeof(buffer), &herrno );
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(WIN32) || defined (__FreeBSD__)
    // gethostbyname in os/x is thread-safe...
    // http://developer.apple.com/technotes/tn2002/pdf/tn2053.pdf
    result = gethostbyname( host.c_str() );
@@ -823,7 +823,7 @@ inet_pton6(const char *src, u_char *dst)
       size_t i;
 
       for (i = 1; i <= n; i++) {
-         endp[- i] = colonp[n - i];
+         endp[n - i] = colonp[n - i];
          colonp[n - i] = 0;
       }
       tp = endp;

--- a/rutil/HashMap.hxx
+++ b/rutil/HashMap.hxx
@@ -3,7 +3,27 @@
 
 // !cj! if all these machine have to use map then we can just delete them and use the default 
 
-#  if ( (__GNUC__ == 4) && (__GNUC_MINOR__ >= 3) ) || ( __GNUC__ > 4 )
+
+#  if (defined(WIN32) && defined(_MSC_VER) && (_MSC_VER >= 1900))
+#    include <map> // force include of nonstandard <bits/c++config.h>
+#    include <unordered_map>
+#    include <unordered_set>
+#    define HASH_MAP_NAMESPACE std
+#    define HashMap std::unordered_map
+#    define HashSet std::unordered_set
+#    define HashMultiMap std::unordered_multimap
+
+#    define HashValue(type)                            \
+     namespace std                                     \
+     {                                                 \
+        template <>                                    \
+        struct hash<type>                              \
+        {                                              \
+           size_t operator()(const type& data) const;  \
+        };                                             \
+     }
+#    define HashValueImp(type, ret) size_t HASH_MAP_NAMESPACE::hash<type>::operator()(const type& data) const { return ret; }
+#  elif ( (__GNUC__ == 4) && (__GNUC_MINOR__ >= 3) ) || ( __GNUC__ > 4 )
 #    include <tr1/unordered_map>
 #    include <tr1/unordered_set>
 #    define HASH_MAP_NAMESPACE std::tr1
@@ -54,11 +74,13 @@ struct hash<type>                                 \
      }                                   
 #    define HashValueImp(type, ret) size_t HASH_MAP_NAMESPACE::hash_value(const type& data) { return ret; }
 #  elif  defined(WIN32) && defined(_MSC_VER) && (_MSC_VER >= 1310)  // hash_map is in stdext namespace for VS.NET 2003
+#    include <map> // force include of nonstandard <bits/c++config.h>
 #    include <hash_map>
 #    include <hash_set>
 #    define HASH_MAP_NAMESPACE stdext
 #    define HashMap stdext::hash_map
 #    define HashSet stdext::hash_set
+#    define HashMultiMap stdext::hash_multimap
 #    define HashValue(type)              \
      namespace HASH_MAP_NAMESPACE        \
      {                                   \

--- a/rutil/Log.cxx
+++ b/rutil/Log.cxx
@@ -311,12 +311,18 @@ Log::tags(Log::Level level,
    char buffer[256];
    Data ts(Data::Borrow, buffer, sizeof(buffer));
 #if defined( __APPLE__ )
-  strm << mDescriptions[level+1] << Log::delim
-        << timestamp(ts) << Log::delim  
-        << mAppName << Log::delim
-        << subsystem << Log::delim 
-        << pthread_self() << Log::delim
-        << pfile << ":" << line;
+  strm 
+//  << mDescriptions[level+1] << Log::delim
+//  << timestamp(ts) << Log::delim  
+	//alexkr // anatol
+#if 1
+//  << mAppName << Log::delim
+//	<< subsystem << Log::delim
+//  << pthread_self() << Log::delim
+ 	<< pfile << ":" << line;
+#else
+	<< subsystem;
+#endif
 #elif defined( WIN32 )
    const char* file = pfile + strlen(pfile);
    while (file != pfile &&
@@ -328,20 +334,22 @@ Log::tags(Log::Level level,
    {
       ++file;
    }
-   strm << mDescriptions[level+1] << Log::delim
-        << timestamp(ts) << Log::delim  
-        << mAppName << Log::delim
-        << subsystem << Log::delim 
-        << GetCurrentThreadId() << Log::delim
+   strm 
+//       << mDescriptions[level+1] << Log::delim
+//        << timestamp(ts) << Log::delim  
+//        << mAppName << Log::delim
+//        << subsystem << Log::delim 
+//        << GetCurrentThreadId() << Log::delim
         << file << ":" << line;
 #else // #if defined( WIN32 ) || defined( __APPLE__ )
-   strm << mDescriptions[level+1] << Log::delim
-        << timestamp(ts) << Log::delim  
+   strm 
+//       << mDescriptions[level+1] << Log::delim
+//        << timestamp(ts) << Log::delim  
 //        << mHostname << Log::delim  
-        << mAppName << Log::delim
-        << subsystem << Log::delim 
+//        << mAppName << Log::delim
+//        << subsystem << Log::delim 
 //        << mPid << Log::delim
-        << pthread_self() << Log::delim
+//        << pthread_self() << Log::delim
         << pfile << ":" << line;
 #endif
    return strm;
@@ -359,7 +367,7 @@ Data&
 Log::timestamp(Data& res) 
 {
    char* datebuf = const_cast<char*>(res.data());
-   const unsigned int datebufSize = 256;
+   const size_t datebufSize = 256;
    res.clear();
    
 #ifdef WIN32 
@@ -682,7 +690,7 @@ Log::Guard::Guard(resip::Log::Level level,
    mStream(mData.clear())
 {
 	
-   if (resip::Log::getLoggerData().mType != resip::Log::OnlyExternalNoHeaders)
+   if (resip::Log::getLoggerData().mType != resip::Log::OnlyExternalNoHeaders && line != 0)
    {
       Log::tags(mLevel, mSubsystem, mFile, mLine, mStream);
       mStream << resip::Log::delim;

--- a/rutil/Socket.hxx
+++ b/rutil/Socket.hxx
@@ -23,7 +23,8 @@
 #ifdef WIN32
 
 typedef int socklen_t;
-
+ 
+#if defined(_MSC_VER) && (_MSC_VER < 1600)
 #define EWOULDBLOCK             WSAEWOULDBLOCK
 #define EINPROGRESS             WSAEINPROGRESS
 #define EALREADY                WSAEALREADY
@@ -33,12 +34,9 @@ typedef int socklen_t;
 #define EPROTOTYPE              WSAEPROTOTYPE
 #define ENOPROTOOPT             WSAENOPROTOOPT
 #define EPROTONOSUPPORT         WSAEPROTONOSUPPORT
-#define ESOCKTNOSUPPORT         WSAESOCKTNOSUPPORT
 #define EOPNOTSUPP              WSAEOPNOTSUPP
-#define EPFNOSUPPORT            WSAEPFNOSUPPORT
 #define EAFNOSUPPORT            WSAEAFNOSUPPORT
 #define EADDRINUSE              WSAEADDRINUSE
-#define EADDRNOTAVAIL           WSAEADDRNOTAVAIL
 #define ENETDOWN                WSAENETDOWN
 #define ENETUNREACH             WSAENETUNREACH
 #define ENETRESET               WSAENETRESET
@@ -47,13 +45,18 @@ typedef int socklen_t;
 #define ENOBUFS                 WSAENOBUFS
 #define EISCONN                 WSAEISCONN
 #define ENOTCONN                WSAENOTCONN
-#define ESHUTDOWN               WSAESHUTDOWN
-#define ETOOMANYREFS            WSAETOOMANYREFS
 #define ETIMEDOUT               WSAETIMEDOUT
 #define ECONNREFUSED            WSAECONNREFUSED
 #define ELOOP                   WSAELOOP
-#define EHOSTDOWN               WSAEHOSTDOWN
 #define EHOSTUNREACH            WSAEHOSTUNREACH
+#define EADDRNOTAVAIL           WSAEADDRNOTAVAIL
+#endif
+
+#define ESOCKTNOSUPPORT         WSAESOCKTNOSUPPORT
+#define EPFNOSUPPORT            WSAEPFNOSUPPORT
+#define ESHUTDOWN               WSAESHUTDOWN
+#define ETOOMANYREFS            WSAETOOMANYREFS
+#define EHOSTDOWN               WSAEHOSTDOWN
 #define EPROCLIM                WSAEPROCLIM
 #define EUSERS                  WSAEUSERS
 #define EDQUOT                  WSAEDQUOT

--- a/rutil/Subsystem.cxx
+++ b/rutil/Subsystem.cxx
@@ -15,6 +15,8 @@ Subsystem Subsystem::TRANSPORT("RESIP:TRANSPORT");
 Subsystem Subsystem::STATS("RESIP:STATS");
 Subsystem Subsystem::REPRO("REPRO:APP");
 Subsystem Subsystem::NONE("UNDEFINED");
+Subsystem Subsystem::B2BSERVER("B2BSERVER");
+
 
 const Data& Subsystem::getSubsystem() const
 {

--- a/rutil/Subsystem.hxx
+++ b/rutil/Subsystem.hxx
@@ -47,6 +47,8 @@ class Subsystem
       static Subsystem TRANSPORT;
       static Subsystem STATS;
       static Subsystem REPRO;
+      static Subsystem B2BSERVER;
+
       
       const Data& getSubsystem() const;
       Log::Level getLevel() const { return mLevel; }

--- a/rutil/SysLogBuf.cxx
+++ b/rutil/SysLogBuf.cxx
@@ -2,6 +2,8 @@
 #include <syslog.h>
 #endif
 
+#include <stdio.h>
+
 #include <cassert>
 #include "rutil/SysLogBuf.hxx"
 

--- a/rutil/ThreadIf.cxx
+++ b/rutil/ThreadIf.cxx
@@ -78,11 +78,16 @@ TlsDestructorInitializer::TlsDestructorInitializer()
 }
 TlsDestructorInitializer::~TlsDestructorInitializer()
 {
+/*
+   This code was commented out by Green.
+   It creates a memory leak, but prevents a crash on exit.
+
    if (--mInstanceCounter == 0)
    {
       delete ThreadIf::mTlsDestructorsMutex;
       delete ThreadIf::mTlsDestructors;
    }
+*/
 }
 #endif
 

--- a/rutil/ThreadIf.hxx
+++ b/rutil/ThreadIf.hxx
@@ -95,6 +95,12 @@ class ThreadIf
       */
       virtual void thread() = 0;
 
+      Id __id() { return mId; }
+
+#ifdef WIN32
+      HANDLE __handle() { return mThread; }
+#endif
+
    protected:
 #ifdef WIN32
       HANDLE mThread;

--- a/rutil/dns/AresDns.cxx
+++ b/rutil/dns/AresDns.cxx
@@ -432,7 +432,8 @@ AresDns::errorMessage(long errorCode)
 void
 AresDns::lookup(const char* target, unsigned short type, ExternalDnsHandler* handler, void* userData)
 {
-   ares_query(mChannel, target, C_IN, type,
+	ares_search(mChannel, target, C_IN, type,
+//   ares_query(mChannel, target, C_IN, type,
 #if defined(USE_ARES)
               resip_AresDns_aresCallback,
 #elif defined(USE_CARES)

--- a/rutil/dns/DnsStub.cxx
+++ b/rutil/dns/DnsStub.cxx
@@ -111,7 +111,13 @@ DnsStub::~DnsStub()
 bool 
 DnsStub::requiresProcess()
 {
-   return (mCommandFifo.size() > 0) || (mQueries.size() > 0);
+   return (mCommandFifo.size() > 0);
+}
+
+bool 
+DnsStub::requiresTimeoutProcessing()
+{
+    return (mQueries.size() > 0);
 }
 
 void 
@@ -197,6 +203,11 @@ void DnsStub::cacheTTL(const Data& key,
                        const unsigned char* abuf, 
                        int alen)
 {
+    // alexkr: submit to community?
+    // avoid crash
+    if (!abuf)
+        return;
+
    // skip header
    const unsigned char* aptr = abuf + HFIXEDSZ;
 

--- a/rutil/dns/DnsStub.hxx
+++ b/rutil/dns/DnsStub.hxx
@@ -159,6 +159,7 @@ class DnsStub : public ExternalDnsHandler
 
       void process(FdSet& fdset);
       bool requiresProcess();
+      bool requiresTimeoutProcessing();
       void buildFdSet(FdSet& fdset);
 
       virtual void handleDnsRaw(ExternalDnsRawResult);

--- a/rutil/dns/LocalDns.cxx
+++ b/rutil/dns/LocalDns.cxx
@@ -90,7 +90,7 @@ void
 LocalDns::lookup(const char* target, unsigned short type, ExternalDnsHandler* handler, void* userData)
 {
    mTarget = target;
-   ares_query(mChannel, target, C_IN, type, LocalDns::localCallback, new Payload(handler, userData));
+   ares_search(mChannel, target, C_IN, type, LocalDns::localCallback, new Payload(handler, userData));
 }
 
 void LocalDns::message(const char* file, unsigned char* buf, int& len)

--- a/rutil/dns/RRCache.cxx
+++ b/rutil/dns/RRCache.cxx
@@ -183,6 +183,22 @@ bool RRCache::lookup(const Data& target,
    }
 }
 
+bool RRCache::check(const Data& target, int type, UInt64& absoluteExpiry)
+{
+   RRList* key = new RRList(target, type);
+   RRSet::iterator it = mRRSet.find(key);
+   delete key;
+   if (it == mRRSet.end())
+   {
+      return false;
+   }
+   else
+   {
+      absoluteExpiry = (*it)->absoluteExpiry();
+	  return true;
+   }
+}
+
 void 
 RRCache::clearCache()
 {

--- a/rutil/dns/RRCache.hxx
+++ b/rutil/dns/RRCache.hxx
@@ -41,12 +41,13 @@ class RRCache
                     const int status,
                     RROverlay overlay);
       bool lookup(const Data& target, int type, int proto, Result& records, int& status);
+	  bool check(const Data& target, int type, UInt64& absoluteExpiry);
       void clearCache();
       void logCache();
 
    private:
       static const int MIN_TO_SEC = 60;
-      static const int DEFAULT_USER_DEFINED_TTL = 10; // in seconds.
+      static const int DEFAULT_USER_DEFINED_TTL = 33; // in seconds.
 
       RRCache();
       static const int DEFAULT_SIZE = 512;

--- a/rutil/stun/Stun.cxx
+++ b/rutil/stun/Stun.cxx
@@ -498,10 +498,12 @@ stunParseMessage( char* buf, unsigned int bufLen, StunMessage& msg, bool verbose
 					
          default:
             if (verbose) clog << "Unknown attribute: " << atrType << endl;
+#if 0			  
             if ( atrType <= 0x7FFF ) 
             {
                return false;
             }
+#endif			  
       }
 		
       body += attrLen;
@@ -806,7 +808,7 @@ stunRand()
       UInt64 tick;
 		
 #if defined(WIN32) 
-#if !defined(UNDER_CE) && !defined(__GNUC__)
+#if !defined(_WIN64) && !defined(UNDER_CE) && !defined(__GNUC__)
       volatile unsigned int lowtick=0,hightick=0;
       __asm
          {


### PR DESCRIPTION
Cleaned-up BP version vs resip 1.6:
 - excluded *.vcproj/*.vcxproj files
 - excluded makefiles
 - applied type conversions, that are made in current version in resip already 